### PR TITLE
feat: show visible startup status message with mock fallback for dev mode

### DIFF
--- a/.pi/extensions/home-assistant/index.ts
+++ b/.pi/extensions/home-assistant/index.ts
@@ -31,11 +31,19 @@ import { registerBlueprintsTool } from "./tools/ha-blueprints.js";
 import { registerCategoriesTool } from "./tools/ha-categories.js";
 import { registerConversationTool } from "./tools/ha-conversation.js";
 import { registerShoppingListTool } from "./tools/ha-shopping-list.js";
+import { registerToolDocsTool } from "./tools/ha-tool-docs.js";
 import { wsClose } from "./lib/ws.js";
-import { gatherContext, getContext } from "./lib/context.js";
+import {
+  gatherContext,
+  getContext,
+  formatContextForLLM,
+  isMockContext,
+  type HAContext,
+} from "./lib/context.js";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
+
 
 // Load APPEND_SYSTEM.md from the extension directory
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -82,30 +90,69 @@ export default function (pi: ExtensionAPI) {
   registerCategoriesTool(pi);
   registerConversationTool(pi);
   registerShoppingListTool(pi);
+  registerToolDocsTool(pi);
 
-  // Gather HA installation context at session start
-  pi.on("session_start", async () => {
+  // Show HA status as a visible chat message at startup (like project extension)
+  pi.on("session_start", async (_event, ctx) => {
     await gatherContext();
+
+    const haCtx = getContext();
+    if (!haCtx) return;
+
+    const devTag = isMockContext() ? " *(mock data — dev mode)*" : "";
+
+    // Build a visible markdown status dashboard
+    const sys = haCtx.system;
+    const domainEntries = Object.entries(haCtx.entities.domains)
+      .sort((a, b) => b[1] - a[1]);
+    const domainList = domainEntries.map(([d, c]) => `${d}: ${c}`).join(", ");
+    const automationCount = haCtx.entities.domains["automation"] || 0;
+
+    const addonLines = haCtx.addons
+      .map((a) => `- ${a.running ? "🟢" : "⚪"} ${a.name} v${a.version}`)
+      .join("\n");
+
+    const areaLine = haCtx.areas?.length
+      ? `\n**Areas:** ${haCtx.areas.join(" · ")}`
+      : "";
+
+    const brief = `# 🏠 Home Assistant${devTag}
+
+| Property | Value |
+|----------|-------|
+| Hostname | ${sys.hostname} |
+| HA Core | ${sys.ha_version} |
+| OS | ${sys.os_name} ${sys.os_version} |
+| Supervisor | ${sys.supervisor_version} (${sys.arch} · ${sys.board}) |
+
+**${haCtx.entities.total}** entities (${domainList}) · **${automationCount}** automations
+
+${addonLines || "No add-ons installed"}${areaLine}`;
+
+    pi.sendMessage(
+      { customType: "ha-status", content: brief, display: true },
+      { triggerTurn: false },
+    );
   });
 
   let contextInjected = false;
 
-  // Inject context as a persistent message on the first turn only
+  // Inject context for LLM only (hidden from user — header shows it visually)
   pi.on("before_agent_start", async (event) => {
     const result: Record<string, unknown> = {};
 
-    // Behavioral system prompt — appended every turn (it's not stored in history)
+    // Behavioral system prompt — appended every turn
     if (systemPromptAppend) {
       result.systemPrompt = event.systemPrompt + "\n\n" + systemPromptAppend;
     }
 
-    // Installation context — injected once as a persistent message
+    // Installation context — injected once, hidden (user sees the header instead)
     if (!contextInjected) {
-      const context = getContext();
-      if (context) {
+      const ctx = getContext();
+      if (ctx) {
         result.message = {
           customType: "ha-context",
-          content: context,
+          content: formatContextForLLM(ctx),
           display: false,
         };
         contextInjected = true;

--- a/.pi/extensions/home-assistant/lib/context.ts
+++ b/.pi/extensions/home-assistant/lib/context.ts
@@ -1,9 +1,8 @@
 /**
- * Gathers Home Assistant installation context at session start
- * and injects it into the system prompt via before_agent_start.
+ * Gathers Home Assistant installation context.
  *
- * Reuses existing API helpers — supervisorApi (WebSocket) for Supervisor
- * endpoints, apiGet for Core REST API, wsSendCommand for registries.
+ * Primary: fetches pre-built structural context from the addon service (localhost:9199/context).
+ * Fallback: gathers directly from HA APIs (dev mode / addon not available).
  */
 import { apiGet } from "./api.js";
 import { HA_TOKEN } from "./config.js";
@@ -16,22 +15,88 @@ interface HAState {
   attributes: Record<string, unknown>;
 }
 
-let cachedContext: string | null = null;
+export interface HAContext {
+  system: {
+    hostname: string;
+    ha_version: string;
+    os_version: string;
+    supervisor_version: string;
+    arch: string;
+    board: string;
+    os_name: string;
+  };
+  entities: {
+    total: number;
+    domains: Record<string, number>;
+  };
+  addons: Array<{ name: string; version: string; running: boolean }>;
+  areas?: string[];
+  gathered_at: string;
+}
+
+let cachedContext: HAContext | null = null;
+let usingMock = false;
 
 /**
- * Gather system info from HA APIs and build a context string.
- * Cached for the session lifetime — called once at session_start.
+ * Returns true when running in local dev mode (not inside the add-on container).
+ * Detected by absence of the container-injected SUPERVISOR_TOKEN env var.
  */
-export async function gatherContext(): Promise<string> {
+export function isDevMode(): boolean {
+  return !process.env.SUPERVISOR_TOKEN;
+}
+
+/**
+ * Mock context for development when HA is unreachable.
+ */
+function mockContext(): HAContext {
+  return {
+    system: {
+      hostname: "dev-mock",
+      ha_version: "2025.1.0 (mock)",
+      os_version: "17.0",
+      supervisor_version: "2025.01.0",
+      arch: "amd64",
+      board: "ova",
+      os_name: "Home Assistant OS",
+    },
+    entities: {
+      total: 42,
+      domains: {
+        light: 12, sensor: 10, switch: 6, automation: 4,
+        binary_sensor: 3, climate: 2, cover: 2, media_player: 2, person: 1,
+      },
+    },
+    addons: [
+      { name: "Pi Agent (dev)", version: "0.0.0", running: true },
+      { name: "File Editor", version: "5.8.0", running: true },
+    ],
+    areas: ["Living Room", "Kitchen", "Bedroom", "Office"],
+    gathered_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Try to fetch context from the addon service, fall back to direct API calls.
+ * In dev mode, returns mock data if all API calls fail.
+ */
+export async function gatherContext(): Promise<HAContext | null> {
   if (cachedContext) return cachedContext;
 
+  // Try addon service first
   try {
-    if (!HA_TOKEN) {
-      cachedContext = "⚠️ No HA_TOKEN configured — cannot gather system context.";
+    const res = await fetch("http://localhost:9199/context");
+    if (res.ok) {
+      cachedContext = (await res.json()) as HAContext;
       return cachedContext;
     }
+  } catch {
+    // Addon not available — fall back to direct gathering
+  }
 
-    // Parallel API calls — reuse existing helpers
+  // Fallback: gather directly (dev mode)
+  try {
+    if (!HA_TOKEN) return null;
+
     const [states, supInfo, osInfo, hostInfo, addonsInfo] = await Promise.allSettled([
       apiGet<HAState[]>("/api/states"),
       supervisorApi<Record<string, unknown>>("/supervisor/info"),
@@ -40,76 +105,109 @@ export async function gatherContext(): Promise<string> {
       supervisorApi<{ addons: any[] }>("/addons"),
     ]);
 
-    // Process states
     const allStates = states.status === "fulfilled" ? states.value : [];
-    const entityCount = allStates.length;
-    const automationCount = allStates.filter((s) =>
-      s.entity_id.startsWith("automation.")
-    ).length;
     const domainCounts: Record<string, number> = {};
     for (const s of allStates) {
       const domain = s.entity_id.split(".")[0];
       domainCounts[domain] = (domainCounts[domain] || 0) + 1;
     }
-    const topDomains = Object.entries(domainCounts)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 15)
-      .map(([d, c]) => `${d}: ${c}`)
-      .join(", ");
 
-    // System info
     const sup: any = supInfo.status === "fulfilled" ? supInfo.value : {};
     const os: any = osInfo.status === "fulfilled" ? osInfo.value : {};
     const host: any = hostInfo.status === "fulfilled" ? hostInfo.value : {};
     const addons: any = addonsInfo.status === "fulfilled" ? addonsInfo.value : {};
 
-    const haVersion = sup.homeassistant || "unknown";
-
-    // Installed add-ons
     const installedAddons = (addons.addons || [])
       .filter((a: any) => a.installed)
-      .map(
-        (a: any) =>
-          `- ${a.name} (v${a.version || "?"})${a.state === "started" ? " — running" : ""}`
-      )
-      .join("\n");
+      .map((a: any) => ({
+        name: a.name,
+        version: a.version || "?",
+        running: a.state === "started",
+      }));
 
-    // Areas (via websocket registry)
-    let areaInfo = "";
+    // Try to get areas
+    let areas: string[] = [];
     try {
-      const areas = (await wsSendCommand({
+      const areaList = (await wsSendCommand({
         type: "config/area_registry/list",
       })) as any[];
-      if (areas.length > 0) {
-        areaInfo = `\n### Areas (${areas.length})\n${areas.map((a: any) => `- ${a.name}`).join("\n")}`;
-      }
-    } catch {
-      // skip if WS not ready
-    }
+      areas = areaList.map((a: any) => a.name);
+    } catch {}
 
-    cachedContext = `# Home Assistant Installation Context
+    cachedContext = {
+      system: {
+        hostname: host.hostname || "unknown",
+        ha_version: sup.homeassistant || "unknown",
+        os_version: os.version || "unknown",
+        supervisor_version: sup.version || "unknown",
+        arch: sup.arch || "unknown",
+        board: os.board || "unknown",
+        os_name: host.operating_system || "unknown",
+      },
+      entities: {
+        total: allStates.length,
+        domains: domainCounts,
+      },
+      addons: installedAddons,
+      areas: areas.length > 0 ? areas : undefined,
+      gathered_at: new Date().toISOString(),
+    };
+
+    return cachedContext;
+  } catch {
+    // In dev mode, fall back to mock data so the UI still works
+    if (isDevMode()) {
+      cachedContext = mockContext();
+      usingMock = true;
+      return cachedContext;
+    }
+    return null;
+  }
+}
+
+/**
+ * Format context as markdown for the LLM system prompt.
+ */
+export function formatContextForLLM(ctx: HAContext): string {
+  const topDomains = Object.entries(ctx.entities.domains)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+    .map(([d, c]) => `${d}: ${c}`)
+    .join(", ");
+
+  const automationCount = ctx.entities.domains["automation"] || 0;
+
+  const addonLines = ctx.addons
+    .map((a) => `- ${a.name} (v${a.version})${a.running ? " — running" : ""}`)
+    .join("\n");
+
+  const areaSection = ctx.areas?.length
+    ? `\n### Areas (${ctx.areas.length})\n${ctx.areas.map((a) => `- ${a}`).join("\n")}`
+    : "";
+
+  return `# Home Assistant Installation Context
 
 ## System
 
 | Property | Value |
 |----------|-------|
-| Hostname | ${host.hostname || "unknown"} |
-| HA Core | ${haVersion} |
-| HAOS | ${os.version || "unknown"} |
-| Supervisor | ${sup.version || "unknown"} |
-| Architecture | ${sup.arch || "unknown"} |
-| Board | ${os.board || "unknown"} |
-| OS | ${host.operating_system || "unknown"} |
+| Hostname | ${ctx.system.hostname} |
+| HA Core | ${ctx.system.ha_version} |
+| HAOS | ${ctx.system.os_version} |
+| Supervisor | ${ctx.system.supervisor_version} |
+| Architecture | ${ctx.system.arch} |
+| Board | ${ctx.system.board} |
+| OS | ${ctx.system.os_name} |
 
 ## Scale
 
-- **${entityCount}** entities total (${topDomains})
+- **${ctx.entities.total}** entities total (${topDomains})
 - **${automationCount}** automations
 
 ## Installed Add-ons
 
-${installedAddons || "- (none or unable to retrieve)"}
-${areaInfo}
+${addonLines || "- (none or unable to retrieve)"}
+${areaSection}
 
 ## Filesystem
 
@@ -126,19 +224,20 @@ ${areaInfo}
 - Service calls have real-world effects — lights, locks, climate, etc.
 - Prefer reload over restart when possible
 - Never delete entities, automations, or helpers without user confirmation`;
-
-    return cachedContext;
-  } catch (err: any) {
-    cachedContext = `⚠️ Could not gather HA context: ${err.message}`;
-    return cachedContext;
-  }
 }
 
 /**
  * Get cached context (returns null if not yet gathered).
  */
-export function getContext(): string | null {
+export function getContext(): HAContext | null {
   return cachedContext;
+}
+
+/**
+ * Returns true if the current context is mock data (no real HA connection).
+ */
+export function isMockContext(): boolean {
+  return usingMock;
 }
 
 /**


### PR DESCRIPTION
## Changes

- **Visible startup dashboard**: Replaced `setHeader` with `pi.sendMessage()` — HA status now appears as a rendered markdown message in the chat on session start (same pattern as the project management extension)
- **Mock context for dev mode**: When all HA API calls fail in dev mode, falls back to realistic mock data so the UI still works without a running HA instance
- **Smart mock detection**: Shows `(mock data — dev mode)` tag only when mock data is actually being used, not just because we're in dev mode
- **Preserves default header**: No longer replaces the pi built-in header (logo + keybinding hints)