### PR TITLE
fix: trigger Docker build on release publish instead of tag push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,11 +2,8 @@
 name: Build and Publish Add-on
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*.*.*"
+  release:
+    types: [published]
   pull_request:
     branches:
       - main
@@ -33,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'release'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -43,7 +40,7 @@ jobs:
       - name: Get version
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
             echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
           else
             echo "version=$(grep '^version:' addon/config.yaml | awk '{print $2}' | tr -d '\"')" >> "$GITHUB_OUTPUT"
@@ -56,4 +53,4 @@ jobs:
             --${{ matrix.arch }} \
             --target ${{ env.ADDON_TARGET }} \
             --version "${{ steps.version.outputs.version }}" \
-            ${{ github.event_name != 'pull_request' && '--no-cache' || '--test' }}
+            ${{ github.event_name == 'release' && '--no-cache' || '--test' }}


### PR DESCRIPTION
## Problem

Two issues with the build workflow:

1. **Release-please creates tags via GitHub API**, which doesn't trigger `push` events in Actions (GitHub's infinite loop prevention). So v0.7.0 never built/published Docker images.
2. **Every push to main** triggered a build (wasteful since release-please handles releases).

## Fix

- Trigger on `release: published` instead of `push: tags`
- Remove `push: branches: main` trigger — only PRs (test) and releases (publish) now
- Login to GHCR and push images only on release events