### PR TITLE
fix: add programmatic confirmation gate to all destructive operations

### DIFF
--- a/.pi/extensions/home-assistant/tools/ha-addons.ts
+++ b/.pi/extensions/home-assistant/tools/ha-addons.ts
@@ -81,6 +81,7 @@ export function registerAddonsTool(pi: ExtensionAPI): void {
       url: Type.Optional(Type.String({ description: "Repository URL for add-repo/remove-repo" })),
       search: Type.Optional(Type.String({ description: "Filter store add-ons by name/slug" })),
       lines: Type.Optional(Type.Number({ description: "Number of log lines to return (default: 100)" })),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -178,6 +179,9 @@ async function executeAction(params: {
 
     case "uninstall": {
       const slug = requireSlug(params.slug);
+      if (!params.confirm) {
+        return `⚠️ **Confirm uninstall**: add-on \`${slug}\`\n\nCall again with \`confirm: true\` to proceed.`;
+      }
       await supervisorApi(`/addons/${slug}/uninstall`, "post");
       return `✅ Add-on \`${slug}\` uninstalled.`;
     }

--- a/.pi/extensions/home-assistant/tools/ha-areas.ts
+++ b/.pi/extensions/home-assistant/tools/ha-areas.ts
@@ -79,6 +79,9 @@ export function registerAreasTool(pi: ExtensionAPI): void {
       level: Type.Optional(
         Type.Number({ description: "Floor level (0=ground, negative=basement, positive=upper)" })
       ),
+      confirm: Type.Optional(
+        Type.Boolean({ description: "Set true to confirm delete-area/delete-floor (default: false, preview only)" })
+      ),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -96,11 +99,11 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "get": return handleGet(params.area_id as string | undefined);
     case "create-area": return handleCreateArea(params);
     case "update-area": return handleUpdateArea(params);
-    case "delete-area": return handleDeleteArea(params.area_id as string | undefined);
+    case "delete-area": return handleDeleteArea(params.area_id as string | undefined, params.confirm as boolean | undefined);
     case "list-floors": return handleListFloors();
     case "create-floor": return handleCreateFloor(params);
     case "update-floor": return handleUpdateFloor(params);
-    case "delete-floor": return handleDeleteFloor(params.floor_id as string | undefined);
+    case "delete-floor": return handleDeleteFloor(params.floor_id as string | undefined, params.confirm as boolean | undefined);
     default:
       throw new Error(`Unknown action '${params.action}'`);
   }
@@ -224,8 +227,11 @@ async function handleUpdateArea(params: Record<string, unknown>): Promise<string
   return `✅ Updated area '${result.name}' (id: ${result.area_id})`;
 }
 
-async function handleDeleteArea(areaId?: string): Promise<string> {
+async function handleDeleteArea(areaId?: string, confirm?: boolean): Promise<string> {
   if (!areaId) throw new Error("'area_id' is required for delete-area");
+  if (!confirm) {
+    return `⚠️ **Confirm delete**: area \`${areaId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await wsCommand("config/area_registry/delete", { area_id: areaId });
   return `✅ Deleted area '${areaId}'`;
 }
@@ -274,8 +280,11 @@ async function handleUpdateFloor(params: Record<string, unknown>): Promise<strin
   return `✅ Updated floor '${result.name}' (id: ${result.floor_id})`;
 }
 
-async function handleDeleteFloor(floorId?: string): Promise<string> {
+async function handleDeleteFloor(floorId?: string, confirm?: boolean): Promise<string> {
   if (!floorId) throw new Error("'floor_id' is required for delete-floor");
+  if (!confirm) {
+    return `⚠️ **Confirm delete**: floor \`${floorId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await wsCommand("config/floor_registry/delete", { floor_id: floorId });
   return `✅ Deleted floor '${floorId}'`;
 }

--- a/.pi/extensions/home-assistant/tools/ha-automations.ts
+++ b/.pi/extensions/home-assistant/tools/ha-automations.ts
@@ -98,6 +98,9 @@ export function registerAutomationsTool(pi: ExtensionAPI): void {
       offset: Type.Optional(
         Type.Number({ description: "Pagination offset (default: 0)" })
       ),
+      confirm: Type.Optional(
+        Type.Boolean({ description: "Set true to confirm destructive actions like delete (default: false, preview only)" })
+      ),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {

--- a/.pi/extensions/home-assistant/tools/ha-automations/crud.ts
+++ b/.pi/extensions/home-assistant/tools/ha-automations/crud.ts
@@ -198,6 +198,9 @@ export async function handleUpdate(params: Record<string, unknown>): Promise<str
 
 export async function handleDelete(params: Record<string, unknown>): Promise<string> {
   const automationId = resolveAutomationId(params);
+  if (!params.confirm) {
+    return `⚠️ **Confirm delete**: automation \`${automationId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await apiDelete(`/api/config/automation/config/${automationId}`);
   return `✅ Deleted automation '${automationId}'\nEntity registry cleaned up automatically.`;
 }

--- a/.pi/extensions/home-assistant/tools/ha-backups.ts
+++ b/.pi/extensions/home-assistant/tools/ha-backups.ts
@@ -43,6 +43,7 @@ export function registerBackupsTool(pi: ExtensionAPI): void {
       folders: Type.Optional(Type.Array(Type.String(), { description: "Folders to include: ssl, share, media, addons/local (for partial create/restore)" })),
       homeassistant: Type.Optional(Type.Boolean({ description: "Include Home Assistant config (for partial create/restore, default: true)" })),
       password: Type.Optional(Type.String({ description: "Password for encrypted backup" })),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -149,6 +150,9 @@ async function executeAction(params: {
 
     case "delete": {
       const slug = requireSlug(params.slug);
+      if (!params.confirm) {
+        return `⚠️ **Confirm delete**: backup \`${slug}\`\n\nCall again with \`confirm: true\` to proceed.`;
+      }
       await supervisorApi(`/backups/${slug}`, "delete");
       return `✅ Backup \`${slug}\` deleted.`;
     }

--- a/.pi/extensions/home-assistant/tools/ha-blueprints.ts
+++ b/.pi/extensions/home-assistant/tools/ha-blueprints.ts
@@ -43,6 +43,7 @@ export function registerBlueprintsTool(pi: ExtensionAPI): void {
       path: Type.Optional(
         Type.String({ description: "Blueprint path to delete (e.g., automation/motion_light.yaml)" })
       ),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -105,6 +106,9 @@ async function handleDelete(params: Record<string, unknown>): Promise<string> {
   const domain = params.domain as string | undefined;
   if (!path) throw new Error("'path' is required for delete");
   if (!domain) throw new Error("'domain' is required for delete");
+  if (!params.confirm) {
+    return `⚠️ **Confirm delete**: blueprint \`${path}\` from ${domain}\n\nCall again with \`confirm: true\` to proceed.`;
+  }
 
   await wsCommand("blueprint/delete", { domain, path });
   return `✅ Deleted blueprint '${path}' from ${domain}`;

--- a/.pi/extensions/home-assistant/tools/ha-categories.ts
+++ b/.pi/extensions/home-assistant/tools/ha-categories.ts
@@ -37,6 +37,7 @@ export function registerCategoriesTool(pi: ExtensionAPI): void {
       ),
       name: Type.Optional(Type.String({ description: "Category name" })),
       icon: Type.Optional(Type.String({ description: "Category icon (e.g., mdi:lightbulb)" })),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -110,6 +111,9 @@ async function handleDelete(params: Record<string, unknown>): Promise<string> {
   const categoryId = params.category_id as string | undefined;
   if (!scope) throw new Error("'scope' is required for delete");
   if (!categoryId) throw new Error("'category_id' is required for delete");
+  if (!params.confirm) {
+    return `⚠️ **Confirm delete**: category \`${categoryId}\` (scope: ${scope})\n\nCall again with \`confirm: true\` to proceed.`;
+  }
 
   await wsCommand("config/category_registry/delete", { scope, category_id: categoryId });
   return `✅ Deleted category '${categoryId}'`;

--- a/.pi/extensions/home-assistant/tools/ha-dashboards.ts
+++ b/.pi/extensions/home-assistant/tools/ha-dashboards.ts
@@ -104,6 +104,9 @@ export function registerDashboardsTool(pi: ExtensionAPI): void {
       search: Type.Optional(
         Type.String({ description: "Filter card types by name (for list-card-types)" })
       ),
+      confirm: Type.Optional(
+        Type.Boolean({ description: "Set true to confirm delete/remove-view/remove-card (default: false, preview only)" })
+      ),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -129,7 +132,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "update":
       return handleUpdate(params);
     case "delete":
-      return handleDelete(params.dashboard_id as string | undefined);
+      return handleDelete(params.dashboard_id as string | undefined, params.confirm as boolean | undefined);
 
     // View operations
     case "get-view":
@@ -139,7 +142,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "update-view":
       return handleUpdateView(params);
     case "remove-view":
-      return handleRemoveView(params);
+      return handleRemoveView(params, params.confirm as boolean | undefined);
     case "move-view":
       return handleMoveView(params);
 
@@ -149,7 +152,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "update-card":
       return handleUpdateCard(params);
     case "remove-card":
-      return handleRemoveCard(params);
+      return handleRemoveCard(params, params.confirm as boolean | undefined);
     case "move-card":
       return handleMoveCard(params);
 
@@ -325,8 +328,11 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
   return `✅ Updated dashboard '${result.title}' (id: ${result.id})`;
 }
 
-async function handleDelete(dashboardId?: string): Promise<string> {
+async function handleDelete(dashboardId?: string, confirm?: boolean): Promise<string> {
   if (!dashboardId) throw new Error("'dashboard_id' is required for delete");
+  if (!confirm) {
+    return `⚠️ **Confirm delete**: dashboard \`${dashboardId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
 
   await wsCommand("lovelace/dashboards/delete", { dashboard_id: dashboardId });
   return `✅ Deleted dashboard '${dashboardId}'`;

--- a/.pi/extensions/home-assistant/tools/ha-dashboards/cards.ts
+++ b/.pi/extensions/home-assistant/tools/ha-dashboards/cards.ts
@@ -129,7 +129,7 @@ export async function handleUpdateCard(params: Record<string, unknown>): Promise
 
 // ── Remove Card ──────────────────────────────────────────────
 
-export async function handleRemoveCard(params: Record<string, unknown>): Promise<string> {
+export async function handleRemoveCard(params: Record<string, unknown>, confirm?: boolean): Promise<string> {
   const urlPath = params.url_path as string | undefined;
   const config = await fetchDashboardConfig(urlPath);
   const views = config.views || [];
@@ -142,6 +142,10 @@ export async function handleRemoveCard(params: Record<string, unknown>): Promise
 
   const { cards } = getViewCards(views, viewIdx);
   const cardIdx = validateCardIndex(cards, params.card_index as number | undefined, "remove-card");
+
+  if (!confirm) {
+    return `⚠️ **Confirm remove-card**: card ${cardIdx} from view ${viewIdx} (type: ${cards[cardIdx]?.type})\n\nCall again with \`confirm: true\` to proceed.`;
+  }
 
   const removed = cards.splice(cardIdx, 1)[0];
   await saveDashboardConfig(urlPath, config);

--- a/.pi/extensions/home-assistant/tools/ha-dashboards/views.ts
+++ b/.pi/extensions/home-assistant/tools/ha-dashboards/views.ts
@@ -86,7 +86,7 @@ export async function handleUpdateView(params: Record<string, unknown>): Promise
 
 // ── Remove View ──────────────────────────────────────────────
 
-export async function handleRemoveView(params: Record<string, unknown>): Promise<string> {
+export async function handleRemoveView(params: Record<string, unknown>, confirm?: boolean): Promise<string> {
   const urlPath = params.url_path as string | undefined;
   const config = await fetchDashboardConfig(urlPath);
   const views = config.views || [];
@@ -96,6 +96,11 @@ export async function handleRemoveView(params: Record<string, unknown>): Promise
     params.view_index as number | undefined,
     params.view_path as string | undefined
   );
+
+  const view = views[idx];
+  if (!confirm) {
+    return `⚠️ **Confirm remove-view**: view ${idx} '${view?.title || "(untitled)"}' (${view?.cards?.length ?? 0} cards)\n\nCall again with \`confirm: true\` to proceed.`;
+  }
 
   const removed = config.views.splice(idx, 1)[0];
   await saveDashboardConfig(urlPath, config);

--- a/.pi/extensions/home-assistant/tools/ha-entities.ts
+++ b/.pi/extensions/home-assistant/tools/ha-entities.ts
@@ -143,7 +143,7 @@ export function registerEntitiesTools(pi: ExtensionAPI): void {
         Type.String({ description: "Set to 'user' to hide, null to unhide" })
       ),
       confirm: Type.Optional(
-        Type.Boolean({ description: "For regenerate-ids: set true to apply renames after previewing (default: false, preview only)" })
+        Type.Boolean({ description: "For remove/regenerate-ids: set true to confirm destructive operation (default: false, preview only)" })
       ),
     }),
 
@@ -167,7 +167,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "update":
       return handleUpdate(params);
     case "remove":
-      return handleRemove(params.entity_id as string | undefined);
+      return handleRemove(params.entity_id as string | undefined, params.confirm as boolean | undefined);
     case "regenerate-ids":
       return handleRegenerateIds(params);
     default:
@@ -412,8 +412,12 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
   return `✅ Updated entity '${updated.entity_id}'\n${changes.map((c) => `  ${c}`).join("\n")}`;
 }
 
-async function handleRemove(entityId?: string): Promise<string> {
+async function handleRemove(entityId?: string, confirm?: boolean): Promise<string> {
   if (!entityId) throw new Error("'entity_id' is required for remove");
+
+  if (!confirm) {
+    return `⚠️ **Confirm remove**: entity \`${entityId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
 
   await wsCommand("config/entity_registry/remove", { entity_id: entityId });
   return `✅ Removed entity '${entityId}' from registry`;

--- a/.pi/extensions/home-assistant/tools/ha-helpers.ts
+++ b/.pi/extensions/home-assistant/tools/ha-helpers.ts
@@ -56,6 +56,9 @@ export function registerHelperTool(pi: ExtensionAPI): void {
           description: "Helper fields for add/update. Use 'list-types' to see required fields per type.",
         })
       ),
+      confirm: Type.Optional(
+        Type.Boolean({ description: "Set true to confirm remove (default: false, preview only)" })
+      ),
 
     }),
 
@@ -93,7 +96,7 @@ async function executeAction(params: {
       return handleUpdate(type, id, fields);
 
     case "remove":
-      return handleRemove(type, id);
+      return handleRemove(type, id, params.confirm as boolean | undefined);
 
     default:
       return `Unknown action '${action}'. Valid: list-types, list, get, add, update, remove`;
@@ -213,8 +216,11 @@ async function handleUpdate(type?: string, id?: string, fields?: Record<string, 
   }
 }
 
-async function handleRemove(type?: string, id?: string): Promise<string> {
+async function handleRemove(type?: string, id?: string, confirm?: boolean): Promise<string> {
   if (!type || !id) return "Error: 'type' and 'id' are required for remove";
+  if (!confirm) {
+    return `⚠️ **Confirm remove**: ${type} helper \`${id}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   const t = requireType(type);
   if (typeof t === "string") return t;
 

--- a/.pi/extensions/home-assistant/tools/ha-integrations.ts
+++ b/.pi/extensions/home-assistant/tools/ha-integrations.ts
@@ -48,6 +48,7 @@ export function registerIntegrationsTool(pi: ExtensionAPI): void {
       search: Type.Optional(
         Type.String({ description: "Search by title or domain" })
       ),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -66,7 +67,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "disable": return handleDisable(params.entry_id as string | undefined);
     case "enable": return handleEnable(params.entry_id as string | undefined);
     case "reload": return handleReload(params.entry_id as string | undefined);
-    case "remove": return handleRemove(params.entry_id as string | undefined);
+    case "remove": return handleRemove(params.entry_id as string | undefined, params.confirm as boolean | undefined);
     default: throw new Error(`Unknown action '${params.action}'`);
   }
 }
@@ -162,8 +163,11 @@ async function handleReload(entryId?: string): Promise<string> {
   return `✅ Reloaded config entry '${entryId}'`;
 }
 
-async function handleRemove(entryId?: string): Promise<string> {
+async function handleRemove(entryId?: string, confirm?: boolean): Promise<string> {
   if (!entryId) throw new Error("'entry_id' is required for remove");
+  if (!confirm) {
+    return `⚠️ **Confirm remove**: integration config entry \`${entryId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
 
   await apiDelete(`/api/config/config_entries/entry/${entryId}`);
   return `✅ Removed config entry '${entryId}'`;

--- a/.pi/extensions/home-assistant/tools/ha-labels.ts
+++ b/.pi/extensions/home-assistant/tools/ha-labels.ts
@@ -46,6 +46,9 @@ export function registerLabelsTool(pi: ExtensionAPI): void {
       description: Type.Optional(
         Type.String({ description: "Label description" })
       ),
+      confirm: Type.Optional(
+        Type.Boolean({ description: "Set true to confirm delete (default: false, preview only)" })
+      ),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -62,7 +65,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "list": return handleList();
     case "create": return handleCreate(params);
     case "update": return handleUpdate(params);
-    case "delete": return handleDelete(params.label_id as string | undefined);
+    case "delete": return handleDelete(params.label_id as string | undefined, params.confirm as boolean | undefined);
     default:
       throw new Error(`Unknown action '${params.action}'`);
   }
@@ -115,8 +118,11 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
   return `✅ Updated label '${result.name}' (id: ${result.label_id})`;
 }
 
-async function handleDelete(labelId?: string): Promise<string> {
+async function handleDelete(labelId?: string, confirm?: boolean): Promise<string> {
   if (!labelId) throw new Error("'label_id' is required for delete");
+  if (!confirm) {
+    return `⚠️ **Confirm delete**: label \`${labelId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await wsCommand("config/label_registry/delete", { label_id: labelId });
   return `✅ Deleted label '${labelId}'`;
 }

--- a/.pi/extensions/home-assistant/tools/ha-people.ts
+++ b/.pi/extensions/home-assistant/tools/ha-people.ts
@@ -38,6 +38,7 @@ export function registerPeopleTool(pi: ExtensionAPI): void {
         Type.Array(Type.String(), { description: "Device tracker entity IDs (e.g., ['device_tracker.phone'])" })
       ),
       picture: Type.Optional(Type.String({ description: "Picture URL path (e.g., /local/photos/john.jpg)" })),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -55,7 +56,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "get": return handleGet(params.id as string | undefined);
     case "create": return handleCreate(params);
     case "update": return handleUpdate(params);
-    case "delete": return handleDelete(params.id as string | undefined);
+    case "delete": return handleDelete(params.id as string | undefined, params.confirm as boolean | undefined);
     default: throw new Error(`Unknown action '${params.action}'`);
   }
 }
@@ -129,8 +130,11 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
   return `✅ Updated person '${result.name}' (id: ${result.id})`;
 }
 
-async function handleDelete(id?: string): Promise<string> {
+async function handleDelete(id?: string, confirm?: boolean): Promise<string> {
   if (!id) throw new Error("'id' is required for delete");
+  if (!confirm) {
+    return `⚠️ **Confirm delete**: person \`${id}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await wsCommand("person/delete", { person_id: id });
   return `✅ Deleted person '${id}'`;
 }

--- a/.pi/extensions/home-assistant/tools/ha-scenes.ts
+++ b/.pi/extensions/home-assistant/tools/ha-scenes.ts
@@ -136,6 +136,9 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
 async function handleDelete(params: Record<string, unknown>): Promise<string> {
   const sceneId = params.scene_id as string;
   if (!sceneId) throw new Error("'scene_id' is required for delete");
+  if (!params.confirm) {
+    return `⚠️ **Confirm delete**: scene \`${sceneId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await apiDelete(`/api/config/scene/config/${sceneId}`);
   return `✅ Deleted scene '${sceneId}'`;
 }
@@ -201,6 +204,7 @@ export function registerScenesTool(pi: ExtensionAPI): void {
       search: Type.Optional(Type.String({ description: "Search scene name/entity_id" })),
       limit: Type.Optional(Type.Number({ description: "Max results (default: 50)" })),
       offset: Type.Optional(Type.Number({ description: "Pagination offset (default: 0)" })),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm delete (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {

--- a/.pi/extensions/home-assistant/tools/ha-scripts.ts
+++ b/.pi/extensions/home-assistant/tools/ha-scripts.ts
@@ -163,6 +163,9 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
 async function handleDelete(params: Record<string, unknown>): Promise<string> {
   const scriptId = params.script_id as string;
   if (!scriptId) throw new Error("'script_id' is required for delete");
+  if (!params.confirm) {
+    return `⚠️ **Confirm delete**: script \`${scriptId}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await apiDelete(`/api/config/script/config/${scriptId}`);
   return `✅ Deleted script '${scriptId}'`;
 }
@@ -279,6 +282,9 @@ export function registerScriptsTool(pi: ExtensionAPI): void {
       ),
       offset: Type.Optional(
         Type.Number({ description: "Pagination offset (default: 0)" })
+      ),
+      confirm: Type.Optional(
+        Type.Boolean({ description: "Set true to confirm delete (default: false, preview only)" })
       ),
     }),
 

--- a/.pi/extensions/home-assistant/tools/ha-tags.ts
+++ b/.pi/extensions/home-assistant/tools/ha-tags.ts
@@ -35,6 +35,7 @@ export function registerTagsTool(pi: ExtensionAPI): void {
       tag_id: Type.Optional(Type.String({ description: "Custom tag ID (for create; auto-generated if omitted)" })),
       name: Type.Optional(Type.String({ description: "Tag name" })),
       description: Type.Optional(Type.String({ description: "Tag description" })),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -52,7 +53,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "get": return handleGet(params.id as string | undefined);
     case "create": return handleCreate(params);
     case "update": return handleUpdate(params);
-    case "delete": return handleDelete(params.id as string | undefined);
+    case "delete": return handleDelete(params.id as string | undefined, params.confirm as boolean | undefined);
     default: throw new Error(`Unknown action '${params.action}'`);
   }
 }
@@ -118,8 +119,11 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
   return `✅ Updated tag '${result.name || result.tag_id}' (id: ${result.id})`;
 }
 
-async function handleDelete(id?: string): Promise<string> {
+async function handleDelete(id?: string, confirm?: boolean): Promise<string> {
   if (!id) throw new Error("'id' is required for delete");
+  if (!confirm) {
+    return `⚠️ **Confirm delete**: tag \`${id}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await wsCommand("tag/delete", { tag_id: id });
   return `✅ Deleted tag '${id}'`;
 }

--- a/.pi/extensions/home-assistant/tools/ha-zones.ts
+++ b/.pi/extensions/home-assistant/tools/ha-zones.ts
@@ -40,6 +40,7 @@ export function registerZonesTool(pi: ExtensionAPI): void {
       radius: Type.Optional(Type.Number({ description: "Radius in meters (default: 100)" })),
       icon: Type.Optional(Type.String({ description: "Icon (e.g., mdi:briefcase)" })),
       passive: Type.Optional(Type.Boolean({ description: "Passive zone (don't trigger enter/leave events)" })),
+      confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
@@ -57,7 +58,7 @@ async function executeAction(params: Record<string, unknown>): Promise<string> {
     case "get": return handleGet(params.id as string | undefined);
     case "create": return handleCreate(params);
     case "update": return handleUpdate(params);
-    case "delete": return handleDelete(params.id as string | undefined);
+    case "delete": return handleDelete(params.id as string | undefined, params.confirm as boolean | undefined);
     default: throw new Error(`Unknown action '${params.action}'`);
   }
 }
@@ -139,8 +140,11 @@ async function handleUpdate(params: Record<string, unknown>): Promise<string> {
   return `✅ Updated zone '${result.name}' (id: ${result.id})`;
 }
 
-async function handleDelete(id?: string): Promise<string> {
+async function handleDelete(id?: string, confirm?: boolean): Promise<string> {
   if (!id) throw new Error("'id' is required for delete");
+  if (!confirm) {
+    return `⚠️ **Confirm delete**: zone \`${id}\`\n\nCall again with \`confirm: true\` to proceed.`;
+  }
   await wsCommand("zone/delete", { id });
   return `✅ Deleted zone '${id}'`;
 }


### PR DESCRIPTION
## Problem

Delete/remove/uninstall actions executed immediately without requiring explicit confirmation. The system prompt told the LLM to confirm, but it could call the tool with the delete action in the same turn without waiting.

## Fix

All destructive actions now require `confirm: true`. Without it, the tool returns a preview:

```
⚠️ **Confirm delete**: automation `my_automation`

Call again with `confirm: true` to proceed.
```

This forces the LLM into a two-step flow — it must show the user what it plans to delete, then make a second call with `confirm: true`.

## Affected tools (16 tools, 18 files)

ha_entities, ha_automations, ha_helpers, ha_scenes, ha_scripts, ha_labels, ha_areas (area + floor), ha_dashboards (dashboard + view + card), ha_zones, ha_people, ha_tags, ha_blueprints, ha_categories, ha_integrations, ha_backups, ha_addons

Fixes #qv7xpxrg