### PR TITLE
feat: align output formatting across all 34 HA tools

### DIFF
--- a/.pi/extensions/home-assistant/lib/format.ts
+++ b/.pi/extensions/home-assistant/lib/format.ts
@@ -2,8 +2,40 @@
  * Shared formatting and string utilities.
  *
  * Common helpers used across multiple tools — time formatting,
- * slugification, element summarization.
+ * slugification, element summarization, and TUI rendering.
  */
+import { Markdown, Text } from "@mariozechner/pi-tui";
+import { getMarkdownTheme } from "@mariozechner/pi-coding-agent";
+
+/**
+ * Shared renderResult for all HA tools — renders markdown output from execute().
+ * Extracts the text content and renders it as formatted markdown in the TUI.
+ */
+export function renderMarkdownResult(result: { content: Array<{ type: string; text?: string }> }): Markdown | Text {
+  const text = result.content?.[0]?.type === "text" ? (result.content[0] as { text: string }).text : "";
+  if (!text) return new Text("", 0, 0);
+  return new Markdown(text, 0, 0, getMarkdownTheme());
+}
+
+/**
+ * Shared renderCall for all HA tools — shows "toolName action" with styling.
+ */
+export function renderToolCall(toolLabel: string, args: Record<string, unknown>, theme: any): Text {
+  let text = theme.fg("toolTitle", theme.bold(`${toolLabel} `));
+  const action = args.action as string | undefined;
+  if (action) {
+    text += theme.fg("accent", action);
+    // Add key context based on common params
+    const id = (args.entity_id || args.device_id || args.area_id || args.slug || args.id || args.domain || "") as string;
+    if (id) text += theme.fg("dim", ` ${id}`);
+    else if (args.search) text += theme.fg("dim", ` "${args.search}"`);
+  } else if (args.template) {
+    text += theme.fg("dim", `${String(args.template).slice(0, 50)}`);
+  } else if (args.tool) {
+    text += theme.fg("accent", String(args.tool));
+  }
+  return new Text(text, 0, 0);
+}
 
 /** Format an ISO date as relative time (e.g., "5m ago", "2h ago") */
 export function timeSince(isoDate: string): string {
@@ -79,6 +111,40 @@ export function parseRelativeTime(input: string): string {
   else throw new Error(`Unknown time unit: ${unit}`);
 
   return new Date(Date.now() - ms).toISOString();
+}
+
+/** Format a trace object (automation or script) into readable markdown */
+export function formatTrace(domain: string, itemId: string, runId: string, trace: Record<string, unknown>): string {
+  const lines: string[] = [];
+  lines.push(`## ${domain} trace: ${itemId} (${runId})`);
+  lines.push("");
+
+  const state = (trace.state as string) || "unknown";
+  const timestamp = trace.timestamp as Record<string, string> | undefined;
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
+  lines.push(`| State | ${state} |`);
+  if (timestamp?.start) lines.push(`| Started | ${timestamp.start} |`);
+  if (timestamp?.finish) lines.push(`| Finished | ${timestamp.finish} |`);
+  if (trace.script_execution) lines.push(`| Execution | ${trace.script_execution} |`);
+  if (trace.error) lines.push(`| Error | ${trace.error} |`);
+
+  const traceSteps = trace.trace as Record<string, unknown[]> | undefined;
+  if (traceSteps) {
+    lines.push("");
+    lines.push("### Steps");
+    lines.push("");
+    for (const [path, steps] of Object.entries(traceSteps)) {
+      for (const step of steps) {
+        const s = step as Record<string, unknown>;
+        const result = s.result ? ` → ${typeof s.result === "object" ? JSON.stringify(s.result) : s.result}` : "";
+        const error = s.error ? ` ❌ ${s.error}` : "";
+        lines.push(`- \`${path}\`${result}${error}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
 }
 
 /** Produce a short one-line summary of an automation element */

--- a/.pi/extensions/home-assistant/tools/ha-addons.ts
+++ b/.pi/extensions/home-assistant/tools/ha-addons.ts
@@ -10,6 +10,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { supervisorApi } from "../lib/supervisor.js";
 import { apiGet } from "../lib/api.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 interface AddonSummary {
   name: string;
@@ -84,6 +85,15 @@ export function registerAddonsTool(pi: ExtensionAPI): void {
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Add-ons", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -119,37 +129,47 @@ async function executeAction(params: {
       if (!addons.length) return "No add-ons installed.";
 
       const sorted = [...addons].sort((a, b) => a.name.localeCompare(b.name));
-      const lines = sorted.map((a) => {
-        const update = a.update_available ? ` → ${a.version_latest}` : "";
-        return `${a.state === "started" ? "🟢" : "⚪"} ${a.slug} — ${a.name} (v${a.version}${update}) [${a.state}]`;
-      });
-      return `**Installed add-ons (${addons.length}):**\n\n${lines.join("\n")}`;
+      const lines: string[] = [
+        "| Status | Name | Slug | Version | State |",
+        "|--------|------|------|---------|-------|",
+        ...sorted.map((a) => {
+          const icon = a.state === "started" ? "🟢" : "⚪";
+          const update = a.update_available ? ` → ${a.version_latest}` : "";
+          return `| ${icon} | **${a.name}** | ${a.slug} | ${a.version}${update} | ${a.state} |`;
+        }),
+        `\n${addons.length} add-ons`,
+      ];
+      return lines.join("\n");
     }
 
     case "get": {
       const slug = requireSlug(params.slug);
       const info = await supervisorApi<AddonInfo>(`/addons/${slug}/info`);
-      const parts = [
-        `**${info.name}** (${info.slug})`,
+      const rows = [
+        `## ${info.name}`,
         "",
-        `State: ${info.state}`,
-        `Version: ${info.version}${info.update_available ? ` → ${info.version_latest} (update available)` : ""}`,
-        `Boot: ${info.boot} | Auto-update: ${info.auto_update ?? false}`,
+        "| Property | Value |",
+        "|----------|-------|",
+        `| Slug | ${info.slug} |`,
+        `| State | ${info.state} |`,
+        `| Version | ${info.version}${info.update_available ? ` → ${info.version_latest} (update available)` : ""} |`,
+        `| Boot | ${info.boot} |`,
+        `| Auto-update | ${info.auto_update ?? false} |`,
       ];
-      if (info.description) parts.push(`Description: ${info.description}`);
-      if (info.url) parts.push(`URL: ${info.url}`);
-      if (info.ingress) parts.push(`Ingress: ${info.ingress_url || "yes"}`);
-      if (info.arch) parts.push(`Architectures: ${info.arch.join(", ")}`);
+      if (info.description) rows.push(`| Description | ${info.description} |`);
+      if (info.url) rows.push(`| URL | ${info.url} |`);
+      if (info.ingress) rows.push(`| Ingress | ${info.ingress_url || "yes"} |`);
+      if (info.arch) rows.push(`| Architectures | ${info.arch.join(", ")} |`);
       if (info.ports && Object.keys(info.ports).length) {
-        parts.push(`Ports: ${Object.entries(info.ports).map(([k, v]) => `${k}→${v}`).join(", ")}`);
+        rows.push(`| Ports | ${Object.entries(info.ports).map(([k, v]) => `${k}→${v}`).join(", ")} |`);
       }
       if (info.options && Object.keys(info.options).length) {
-        parts.push("", "**Current options:**", "```json", JSON.stringify(info.options, null, 2), "```");
+        rows.push("", "### Current options", "", "```json", JSON.stringify(info.options, null, 2), "```");
       }
       if (info.schema) {
-        parts.push("", "**Config schema:**", "```json", JSON.stringify(info.schema, null, 2), "```");
+        rows.push("", "### Config schema", "", "```json", JSON.stringify(info.schema, null, 2), "```");
       }
-      return parts.join("\n");
+      return rows.join("\n");
     }
 
     // ── Lifecycle ────────────────────────────────────────────
@@ -212,12 +232,16 @@ async function executeAction(params: {
       const slug = requireSlug(params.slug);
       const s = await supervisorApi<AddonStats>(`/addons/${slug}/stats`);
       return [
-        `**Stats for \`${slug}\`:**`,
+        `## Stats for \`${slug}\``,
         "",
-        `CPU: ${s.cpu_percent.toFixed(1)}%`,
-        `Memory: ${formatBytes(s.memory_usage)} / ${formatBytes(s.memory_limit)} (${s.memory_percent.toFixed(1)}%)`,
-        `Network: ↓ ${formatBytes(s.network_rx)} / ↑ ${formatBytes(s.network_tx)}`,
-        `Disk: R ${formatBytes(s.blk_read)} / W ${formatBytes(s.blk_write)}`,
+        "| Metric | Value |",
+        "|--------|-------|",
+        `| CPU | ${s.cpu_percent.toFixed(1)}% |`,
+        `| Memory | ${formatBytes(s.memory_usage)} / ${formatBytes(s.memory_limit)} (${s.memory_percent.toFixed(1)}%) |`,
+        `| Network ↓ | ${formatBytes(s.network_rx)} |`,
+        `| Network ↑ | ${formatBytes(s.network_tx)} |`,
+        `| Disk read | ${formatBytes(s.blk_read)} |`,
+        `| Disk write | ${formatBytes(s.blk_write)} |`,
       ].join("\n");
     }
 
@@ -253,12 +277,16 @@ async function executeAction(params: {
 
       const sorted = [...addons].sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
       const limited = sorted.slice(0, 50);
-      const lines = limited.map((a) => {
-        const installed = a.installed ? " ✓" : "";
-        return `${a.slug} — ${a.name}${installed}`;
-      });
-      const suffix = sorted.length > 50 ? `\n\n… and ${sorted.length - 50} more. Use 'search' to filter.` : "";
-      return `**Add-on store (${sorted.length} add-ons):**\n\n${lines.join("\n")}${suffix}`;
+      const lines: string[] = [
+        "| Name | Slug | Installed |",
+        "|------|------|-----------|",
+        ...limited.map((a) => `| **${a.name}** | ${a.slug} | ${a.installed ? "✓" : ""} |`),
+      ];
+      const countLine = sorted.length > 50
+        ? `Showing 50 of ${sorted.length} add-ons. Use 'search' to filter.`
+        : `${sorted.length} add-ons`;
+      lines.push(`\n${countLine}`);
+      return lines.join("\n");
     }
 
     case "store-refresh": {
@@ -271,8 +299,13 @@ async function executeAction(params: {
       const data = await supervisorApi<{ repositories: StoreRepo[] }>("/store/repositories");
       const repos = data.repositories ?? (data as unknown as StoreRepo[]);
       if (!repos.length) return "No repositories configured.";
-      const lines = repos.map((r) => `- **${r.name || r.slug}**: ${r.source || r.url}`);
-      return `**Add-on repositories (${repos.length}):**\n\n${lines.join("\n")}`;
+      const lines: string[] = [
+        "| Name | Source |",
+        "|------|--------|",
+        ...repos.map((r) => `| **${r.name || r.slug}** | ${r.source || r.url} |`),
+        `\n${repos.length} repositories`,
+      ];
+      return lines.join("\n");
     }
 
     case "add-repo": {

--- a/.pi/extensions/home-assistant/tools/ha-areas.ts
+++ b/.pi/extensions/home-assistant/tools/ha-areas.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -83,6 +84,15 @@ export function registerAreasTool(pi: ExtensionAPI): void {
         Type.Boolean({ description: "Set true to confirm delete-area/delete-floor (default: false, preview only)" })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Areas", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
@@ -195,7 +205,35 @@ async function handleGet(areaId?: string): Promise<string> {
     .filter((e) => e.area_id === areaId)
     .map((e) => e.entity_id);
 
-  return JSON.stringify({ ...area, devices: areaDevices, entities: areaEntities }, null, 2);
+  const lines: string[] = [];
+  lines.push(`## ${area.name}`);
+  lines.push("");
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
+  lines.push(`| ID | ${area.area_id} |`);
+  if (area.floor_id) lines.push(`| Floor | ${area.floor_id} |`);
+  if (area.icon) lines.push(`| Icon | ${area.icon} |`);
+  if (area.aliases?.length) lines.push(`| Aliases | ${area.aliases.join(", ")} |`);
+  if (area.labels?.length) lines.push(`| Labels | ${area.labels.join(", ")} |`);
+
+  if (areaDevices.length > 0) {
+    lines.push("");
+    lines.push(`### Devices (${areaDevices.length})`);
+    for (const d of areaDevices) { lines.push(`- ${d.name} (${d.id})`); }
+  }
+
+  if (areaEntities.length > 0) {
+    lines.push("");
+    lines.push(`### Entities (${areaEntities.length})`);
+    for (const e of areaEntities) { lines.push(`- ${e}`); }
+  }
+
+  if (areaDevices.length === 0 && areaEntities.length === 0) {
+    lines.push("");
+    lines.push("*No devices or entities assigned.*");
+  }
+
+  return lines.join("\n");
 }
 
 async function handleCreateArea(params: Record<string, unknown>): Promise<string> {
@@ -244,12 +282,12 @@ async function handleListFloors(): Promise<string> {
 
   if (floors.length === 0) return "No floors defined.";
 
-  const lines = floors.map((f) => {
-    const levelStr = f.level !== null ? ` (level ${f.level})` : "";
-    const iconStr = f.icon ? ` ${f.icon}` : "";
-    return `${f.name}${levelStr}${iconStr} — id: ${f.floor_id}`;
-  });
-
+  const lines: string[] = [
+    "| Name | Level | Icon | ID |",
+    "|------|-------|------|----|",
+    ...floors.map((f) => `| **${f.name}** | ${f.level ?? ""} | ${f.icon || ""} | ${f.floor_id} |`),
+    `\n${floors.length} floors`,
+  ];
   return lines.join("\n");
 }
 

--- a/.pi/extensions/home-assistant/tools/ha-automations.ts
+++ b/.pi/extensions/home-assistant/tools/ha-automations.ts
@@ -27,6 +27,7 @@ import { handleNew, handleLoad, handleListDrafts, handleShow, handleYaml, handle
 import { handleListTypes, handleAddElement, handleUpdateElement, handleRemoveElement } from "./ha-automations/elements.js";
 import { handleGetServiceSchema } from "./ha-automations/service-schema.js";
 import { handleImportYaml } from "./ha-automations/import.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Tool registration ────────────────────────────────────────
 
@@ -102,6 +103,15 @@ export function registerAutomationsTool(pi: ExtensionAPI): void {
         Type.Boolean({ description: "Set true to confirm destructive actions like delete (default: false, preview only)" })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Automations", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await dispatch(params);

--- a/.pi/extensions/home-assistant/tools/ha-automations/builder.ts
+++ b/.pi/extensions/home-assistant/tools/ha-automations/builder.ts
@@ -115,18 +115,21 @@ export function handleListDrafts(): string {
     return "No drafts found. Use 'new' to create one or 'load' to edit an existing automation.";
   }
 
-  const lines: string[] = [`${files.length} draft(s):\n`];
+  const lines: string[] = [
+    "| Name | Source | Triggers | Conditions | Actions | Mode | Modified |",
+    "|------|--------|----------|------------|---------|------|----------|",
+  ];
   for (const f of files.sort()) {
     try {
       const draft = readDraftFile(f);
-      const source = draft._meta.source_id ? ` (editing: ${draft._meta.source_id})` : " (new)";
-      lines.push(`📋 ${draft.alias}${source}`);
-      lines.push(`   T:${draft.triggers.length} C:${draft.conditions.length} A:${draft.actions.length} | mode: ${draft.mode} | modified: ${timeSince(draft._meta.modified)}`);
+      const source = draft._meta.source_id ? `editing: ${draft._meta.source_id}` : "new";
+      lines.push(`| **${draft.alias}** | ${source} | ${draft.triggers.length} | ${draft.conditions.length} | ${draft.actions.length} | ${draft.mode} | ${timeSince(draft._meta.modified)} |`);
     } catch {
-      lines.push(`❌ ${f} (corrupt)`);
+      lines.push(`| ❌ ${f} | corrupt | | | | | |`);
     }
   }
 
+  lines.push(`\n${files.length} drafts`);
   return lines.join("\n");
 }
 
@@ -134,7 +137,7 @@ export function handleShow(params: Record<string, unknown>): string {
   const alias = requireAlias(params);
   const draft = loadDraft(alias);
   const config = draftToConfig(draft);
-  return draftSummary(draft) + "\n\n" + JSON.stringify(config, null, 2);
+  return draftSummary(draft) + "\n\n```yaml\n" + toYaml(config).trim() + "\n```";
 }
 
 export function handleYaml(params: Record<string, unknown>): string {

--- a/.pi/extensions/home-assistant/tools/ha-automations/crud.ts
+++ b/.pi/extensions/home-assistant/tools/ha-automations/crud.ts
@@ -8,6 +8,7 @@ import { apiGet, apiPost, apiDelete } from "../../lib/api.js";
 import { timeSince } from "../../lib/format.js";
 import { validateAutomationConfig } from "../../lib/validation.js";
 import type { HAState, AutomationConfig } from "../../lib/types.js";
+import { toYaml } from "../../lib/yaml.js";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -56,25 +57,16 @@ export async function handleList(params: Record<string, unknown>): Promise<strin
   const total = automations.length;
   const page = automations.slice(offset, offset + limit);
 
-  const lines: string[] = [];
+  const rows: string[] = [];
+  rows.push("| | Name | Entity | Mode | Last triggered |");
+  rows.push("|---|------|--------|------|----------------|");
   for (const a of page) {
     const name = (a.attributes.friendly_name as string) || a.entity_id;
-    const configId = a.attributes.id as string;
     const lastTriggered = a.attributes.last_triggered as string;
-    const mode = a.attributes.mode as string;
+    const mode = (a.attributes.mode as string) || "single";
     const stateIcon = a.state === "on" ? "🟢" : "🔴";
-
-    const line = `${stateIcon} ${name}`;
-    const meta: string[] = [];
-    if (configId) meta.push(`id: ${configId}`);
-    meta.push(`entity: ${a.entity_id}`);
-    if (mode && mode !== "single") meta.push(`mode: ${mode}`);
-    if (lastTriggered) {
-      const ago = timeSince(lastTriggered);
-      meta.push(`last: ${ago}`);
-    }
-    lines.push(line);
-    lines.push(`  ${meta.join(" | ")}`);
+    const ago = lastTriggered ? timeSince(lastTriggered) : "—";
+    rows.push(`| ${stateIcon} | ${name} | ${a.entity_id} | ${mode} | ${ago} |`);
   }
 
   let summary: string;
@@ -84,7 +76,7 @@ export async function handleList(params: Record<string, unknown>): Promise<strin
     summary = `Showing ${offset + 1}-${Math.min(offset + limit, total)} of ${total} automations`;
   }
 
-  return lines.join("\n") + "\n\n" + summary;
+  return rows.join("\n") + "\n\n" + summary;
 }
 
 // ── Get ──────────────────────────────────────────────────────
@@ -123,26 +115,40 @@ export async function handleGet(params: Record<string, unknown>): Promise<string
     } catch { /* not available */ }
   }
 
-  const result: Record<string, unknown> = {};
-
-  if (state) {
-    result.entity_id = state.entity_id;
-    result.state = state.state;
-    result.friendly_name = state.attributes.friendly_name;
-    result.last_triggered = state.attributes.last_triggered;
-    result.mode = state.attributes.mode;
-    result.current = state.attributes.current;
-  }
-
-  if (config) {
-    result.config = config;
-  }
-
   if (!state && !config) {
     throw new Error(`Automation not found. Provide a valid entity_id or automation_id.`);
   }
 
-  return JSON.stringify(result, null, 2);
+  const lines: string[] = [];
+  const name = state?.attributes.friendly_name || config?.alias || entityId || "(unnamed)";
+  lines.push(`## ${name}`);
+  lines.push("");
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
+  if (state) {
+    lines.push(`| Entity | ${state.entity_id} |`);
+    lines.push(`| State | ${state.state} |`);
+    lines.push(`| Mode | ${state.attributes.mode || "single"} |`);
+    if (state.attributes.last_triggered) lines.push(`| Last triggered | ${state.attributes.last_triggered} |`);
+    if (state.attributes.current) lines.push(`| Current runs | ${state.attributes.current} |`);
+  }
+  if (config) {
+    if (config.description) lines.push(`| Description | ${config.description} |`);
+    const triggers = config.triggers || config.trigger;
+    const conditions = config.conditions || config.condition;
+    const actions = config.actions || config.action;
+    if (Array.isArray(triggers)) lines.push(`| Triggers | ${triggers.length} |`);
+    if (Array.isArray(conditions)) lines.push(`| Conditions | ${conditions.length} |`);
+    if (Array.isArray(actions)) lines.push(`| Actions | ${actions.length} |`);
+    lines.push("");
+    lines.push("### Config");
+    lines.push("");
+    lines.push("```yaml");
+    lines.push(toYaml(config).trim());
+    lines.push("```");
+  }
+
+  return lines.join("\n");
 }
 
 // ── Create ───────────────────────────────────────────────────

--- a/.pi/extensions/home-assistant/tools/ha-automations/service-schema.ts
+++ b/.pi/extensions/home-assistant/tools/ha-automations/service-schema.ts
@@ -73,12 +73,13 @@ export async function handleGetServiceSchema(params: Record<string, unknown>): P
     }
   }
 
-  lines.push(`\nExample action config:`);
+  lines.push(`\nExample action config:\n\`\`\`json`);
   lines.push(JSON.stringify({
     action: service,
     target: { entity_id: `${domain}.example` },
     data: {},
   }, null, 2));
+  lines.push("```");
 
   return lines.join("\n");
 }

--- a/.pi/extensions/home-assistant/tools/ha-automations/traces.ts
+++ b/.pi/extensions/home-assistant/tools/ha-automations/traces.ts
@@ -2,7 +2,7 @@
  * Automation trace handlers — list traces and get trace detail.
  */
 import { wsCommand } from "../../lib/ws.js";
-import { timeSince } from "../../lib/format.js";
+import { timeSince, formatTrace } from "../../lib/format.js";
 import type { TraceListEntry } from "../../lib/types.js";
 import { resolveAutomationId } from "./crud.js";
 
@@ -23,19 +23,18 @@ export async function handleTraces(params: Record<string, unknown>): Promise<str
   const limit = (params.limit as number) || 20;
   const page = traces.slice(0, limit);
 
-  const lines: string[] = [];
+  const lines: string[] = [
+    "| Status | Automation | Execution | Run ID | Last Step | Time |",
+    "|--------|-----------|-----------|--------|-----------|------|",
+  ];
   for (const t of page) {
     const stateIcon = t.state === "stopped" ? "✅" : t.state === "running" ? "🔄" : "❌";
     const ago = timeSince(t.timestamp.start);
     const execution = t.script_execution || "unknown";
-    const itemId = t.item_id;
-
-    lines.push(`${stateIcon} ${itemId} — ${execution} (${ago})`);
-    lines.push(`  run_id: ${t.run_id} | last_step: ${t.last_step || "none"}`);
+    lines.push(`| ${stateIcon} | ${t.item_id} | ${execution} | ${t.run_id} | ${t.last_step || "none"} | ${ago} |`);
   }
 
-  lines.push("");
-  lines.push(`${traces.length} traces total (showing ${page.length})`);
+  lines.push(`\n${traces.length} traces (showing ${page.length})`);
   return lines.join("\n");
 }
 
@@ -50,5 +49,5 @@ export async function handleTrace(params: Record<string, unknown>): Promise<stri
     run_id: runId,
   });
 
-  return JSON.stringify(trace, null, 2);
+  return formatTrace("automation", automationId, runId, trace);
 }

--- a/.pi/extensions/home-assistant/tools/ha-backups.ts
+++ b/.pi/extensions/home-assistant/tools/ha-backups.ts
@@ -7,6 +7,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { supervisorApi } from "../lib/supervisor.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 interface BackupSummary {
   slug: string;
@@ -46,6 +47,15 @@ export function registerBackupsTool(pi: ExtensionAPI): void {
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Backups", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -81,33 +91,43 @@ async function executeAction(params: {
       if (!backups.length) return "No backups found.";
 
       const sorted = [...backups].sort((a, b) => b.date.localeCompare(a.date));
-      const lines = sorted.map((b) => {
-        const date = b.date.slice(0, 19).replace("T", " ");
-        const prot = b.protected ? " 🔒" : "";
-        return `\`${b.slug}\` ${date} — ${b.name} (${b.type}, ${formatSize(b.size)})${prot}`;
-      });
-      return `**Backups (${backups.length}):**\n\n${lines.join("\n")}`;
+      const lines: string[] = [
+        "| Name | Slug | Date | Type | Size | Protected |",
+        "|------|------|------|------|------|-----------|",
+        ...sorted.map((b) => {
+          const date = b.date.slice(0, 19).replace("T", " ");
+          const prot = b.protected ? "🔒" : "";
+          return `| **${b.name}** | \`${b.slug}\` | ${date} | ${b.type} | ${formatSize(b.size)} | ${prot} |`;
+        }),
+        `\n${backups.length} backups`,
+      ];
+      return lines.join("\n");
     }
 
     case "get": {
       const slug = requireSlug(params.slug);
       const info = await supervisorApi<BackupInfo>(`/backups/${slug}/info`);
-      const parts = [
-        `**${info.name}** (\`${info.slug}\`)`,
+      const rows = [
+        `## ${info.name}`,
         "",
-        `Type: ${info.type}`,
-        `Date: ${info.date.slice(0, 19).replace("T", " ")}`,
-        `Size: ${formatSize(info.size)}`,
-        `Protected: ${info.protected ? "yes 🔒" : "no"}`,
+        "| Property | Value |",
+        "|----------|-------|",
+        `| Slug | \`${info.slug}\` |`,
+        `| Type | ${info.type} |`,
+        `| Date | ${info.date.slice(0, 19).replace("T", " ")} |`,
+        `| Size | ${formatSize(info.size)} |`,
+        `| Protected | ${info.protected ? "yes 🔒" : "no"} |`,
       ];
-      if (info.homeassistant) parts.push(`HA version: ${info.homeassistant}`);
+      if (info.homeassistant) rows.push(`| HA version | ${info.homeassistant} |`);
       if (info.addons?.length) {
-        parts.push("", "**Add-ons:**");
-        for (const a of info.addons) parts.push(`- ${a.name} (${a.slug}) v${a.version}`);
+        rows.push("", "### Add-ons", "");
+        rows.push("| Name | Slug | Version |");
+        rows.push("|------|------|---------|");
+        for (const a of info.addons) rows.push(`| ${a.name} | ${a.slug} | ${a.version} |`);
       }
-      if (info.folders?.length) parts.push("", `**Folders:** ${info.folders.join(", ")}`);
-      if (info.repositories?.length) parts.push("", `**Repositories:** ${info.repositories.length}`);
-      return parts.join("\n");
+      if (info.folders?.length) rows.push("", `**Folders:** ${info.folders.join(", ")}`);
+      if (info.repositories?.length) rows.push("", `**Repositories:** ${info.repositories.length}`);
+      return rows.join("\n");
     }
 
     case "create-full": {

--- a/.pi/extensions/home-assistant/tools/ha-blueprints.ts
+++ b/.pi/extensions/home-assistant/tools/ha-blueprints.ts
@@ -9,6 +9,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
 import { apiPost, apiDelete } from "../lib/api.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -46,6 +47,15 @@ export function registerBlueprintsTool(pi: ExtensionAPI): void {
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Blueprints", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -77,12 +87,13 @@ async function handleList(domain?: string): Promise<string> {
     if (entries.length === 0) continue;
 
     lines.push(`## ${d}`);
+    lines.push("| Name | Path | Author | Source |");
+    lines.push("|------|------|--------|--------|");
     for (const [path, bp] of entries) {
       if (!bp) continue;
-      const parts = [`**${bp.metadata.name}**`];
-      if (bp.metadata.author) parts.push(`by ${bp.metadata.author}`);
-      if (bp.metadata.source_url) parts.push(`source: ${bp.metadata.source_url}`);
-      lines.push(`  ${parts.join(" — ")} (${path})`);
+      const author = bp.metadata.author || "";
+      const source = bp.metadata.source_url || "";
+      lines.push(`| **${bp.metadata.name}** | ${path} | ${author} | ${source} |`);
       total++;
     }
     lines.push("");

--- a/.pi/extensions/home-assistant/tools/ha-categories.ts
+++ b/.pi/extensions/home-assistant/tools/ha-categories.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -40,6 +41,15 @@ export function registerCategoriesTool(pi: ExtensionAPI): void {
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Categories", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -68,14 +78,12 @@ async function handleList(scope?: string): Promise<string> {
   if (categories.length === 0) return `No categories defined for ${scope}.`;
 
   categories.sort((a, b) => a.name.localeCompare(b.name));
-  const lines = categories.map((c) => {
-    const parts = [c.name];
-    if (c.icon) parts.push(c.icon);
-    return `${parts.join(" — ")} (id: ${c.category_id})`;
-  });
-
-  lines.push("");
-  lines.push(`${categories.length} ${scope} categories`);
+  const lines: string[] = [
+    "| Name | Icon | ID |",
+    "|------|------|----|",
+    ...categories.map((c) => `| **${c.name}** | ${c.icon || ""} | ${c.category_id} |`),
+    `\n${categories.length} ${scope} categories`,
+  ];
   return lines.join("\n");
 }
 

--- a/.pi/extensions/home-assistant/tools/ha-conversation.ts
+++ b/.pi/extensions/home-assistant/tools/ha-conversation.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -52,6 +53,15 @@ export function registerConversationTool(pi: ExtensionAPI): void {
       ),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Conversation", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -84,24 +94,26 @@ async function handleProcess(params: Record<string, unknown>): Promise<string> {
   const speech = result.response?.speech?.plain?.speech ?? "(no response)";
   const type = result.response?.response_type ?? "unknown";
 
-  const lines = [
-    `**Response:** ${speech}`,
-    `**Type:** ${type}`,
+  const rows: string[] = [
+    "| Property | Value |",
+    "|----------|-------|",
+    `| Response | ${speech} |`,
+    `| Type | ${type} |`,
   ];
 
   if (result.conversation_id) {
-    lines.push(`**Conversation ID:** ${result.conversation_id}`);
+    rows.push(`| Conversation ID | ${result.conversation_id} |`);
   }
 
   const respData = result.response?.data;
   if (respData?.targets && Array.isArray(respData.targets) && respData.targets.length > 0) {
-    lines.push(`**Targets:** ${JSON.stringify(respData.targets)}`);
+    rows.push(`| Targets | ${JSON.stringify(respData.targets)} |`);
   }
   if (respData?.failed && Array.isArray(respData.failed) && respData.failed.length > 0) {
-    lines.push(`**Failed:** ${JSON.stringify(respData.failed)}`);
+    rows.push(`| Failed | ${JSON.stringify(respData.failed)} |`);
   }
 
-  return lines.join("\n");
+  return rows.join("\n");
 }
 
 async function handleAgents(): Promise<string> {
@@ -109,8 +121,11 @@ async function handleAgents(): Promise<string> {
   const agents = result.agents ?? [];
   if (agents.length === 0) return "No conversation agents available.";
 
-  const lines = agents.map((a) => `**${a.name}** (id: ${a.id})`);
-  lines.push("");
-  lines.push(`${agents.length} agents`);
+  const lines: string[] = [
+    "| Name | ID |",
+    "|------|----|",
+    ...agents.map((a) => `| **${a.name}** | ${a.id} |`),
+    `\n${agents.length} agents`,
+  ];
   return lines.join("\n");
 }

--- a/.pi/extensions/home-assistant/tools/ha-dashboards.ts
+++ b/.pi/extensions/home-assistant/tools/ha-dashboards.ts
@@ -35,6 +35,7 @@ import {
   handleMoveCard,
 } from "./ha-dashboards/cards.js";
 import { handleListCardTypes } from "./ha-dashboards/card-types.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Tool registration ────────────────────────────────────────
 
@@ -109,6 +110,15 @@ export function registerDashboardsTool(pi: ExtensionAPI): void {
       ),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Dashboards", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -174,38 +184,39 @@ async function handleList(): Promise<string> {
     return "No custom dashboards. The default dashboard exists at url_path: null.";
   }
 
-  const lines: string[] = ["## Dashboards\n"];
+  const rows: Array<{ title: string; id: string; urlPath: string; icon: string; views: string; flags: string }> = [];
 
-  // Always mention the default dashboard
+  // Default dashboard
   try {
     const defaultConfig = await fetchDashboardConfig(undefined);
-    const viewCount = defaultConfig.views?.length ?? 0;
-    lines.push(`**Default Dashboard** (url_path: null)`);
-    lines.push(`  ${viewCount} views\n`);
+    rows.push({ title: "Default Dashboard", id: "—", urlPath: "(null)", icon: "", views: `${defaultConfig.views?.length ?? 0}`, flags: "" });
   } catch {
-    lines.push(`**Default Dashboard** (url_path: null)`);
-    lines.push(`  auto-generated (no custom config)\n`);
+    rows.push({ title: "Default Dashboard", id: "—", urlPath: "(null)", icon: "", views: "auto", flags: "" });
   }
 
   for (const d of dashboards) {
-    const icon = d.icon ? ` ${d.icon}` : "";
-    const admin = d.require_admin ? " [admin]" : "";
-    const sidebar = d.show_in_sidebar ? "" : " [hidden from sidebar]";
-    const mode = d.mode === "yaml" ? " (YAML)" : "";
-    lines.push(`**${d.title}**${icon}${admin}${sidebar}${mode}`);
-    lines.push(`  id: ${d.id} | url_path: ${d.url_path}`);
-
+    const flags: string[] = [];
+    if (d.require_admin) flags.push("admin");
+    if (!d.show_in_sidebar) flags.push("hidden");
+    if (d.mode === "yaml") flags.push("YAML");
+    let views = "";
     if (d.mode === "storage") {
       try {
         const config = await fetchDashboardConfig(d.url_path);
-        lines.push(`  ${config.views?.length ?? 0} views`);
+        views = `${config.views?.length ?? 0}`;
       } catch {
-        lines.push(`  no config yet`);
+        views = "—";
       }
     }
-    lines.push("");
+    rows.push({ title: d.title, id: d.id, urlPath: d.url_path, icon: d.icon || "", views, flags: flags.join(", ") });
   }
 
+  const lines: string[] = [
+    "| Title | URL Path | ID | Icon | Views | Flags |",
+    "|-------|----------|----|------|-------|-------|",
+    ...rows.map((r) => `| **${r.title}** | ${r.urlPath} | ${r.id} | ${r.icon} | ${r.views} | ${r.flags} |`),
+    `\n${rows.length} dashboards`,
+  ];
   return lines.join("\n");
 }
 

--- a/.pi/extensions/home-assistant/tools/ha-dashboards/views.ts
+++ b/.pi/extensions/home-assistant/tools/ha-dashboards/views.ts
@@ -9,6 +9,7 @@ import {
   resolveViewIndex,
   type ViewConfig,
 } from "./types.js";
+import { toYaml } from "../../lib/yaml.js";
 
 // ── Get View ─────────────────────────────────────────────────
 
@@ -24,7 +25,7 @@ export async function handleGetView(params: Record<string, unknown>): Promise<st
   );
 
   const view = views[idx];
-  return `## View ${idx}: ${view.title || "(untitled)"}\n\n${JSON.stringify(view, null, 2)}`;
+  return `## View ${idx}: ${view.title || "(untitled)"}\n\n\`\`\`yaml\n${toYaml(view).trim()}\n\`\`\``;
 }
 
 // ── Add View ─────────────────────────────────────────────────

--- a/.pi/extensions/home-assistant/tools/ha-devices.ts
+++ b/.pi/extensions/home-assistant/tools/ha-devices.ts
@@ -11,6 +11,7 @@ import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
 import { apiGet } from "../lib/api.js";
 import type { HAState } from "../lib/types.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -173,6 +174,15 @@ export function registerDevicesTool(pi: ExtensionAPI): void {
       ),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Devices", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -274,30 +284,19 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
   const page = filtered.slice(offset, offset + limit);
 
   // Format output
-  const lines: string[] = [];
+  const lines: string[] = [
+    "| Name | Manufacturer | Model | Integration | Area | ID |",
+    "|------|-------------|-------|-------------|------|----|",
+  ];
   for (const d of page) {
     const name = getDisplayName(d);
     const integrations = getIntegrations(d, configEntries);
-    const area = d.area_id ? areaReg.get(d.area_id)?.name : null;
-    const parts: string[] = [];
-
-    // First line: name + basic info
-    let line = `${name}`;
-    if (d.manufacturer || d.model) {
-      const hw = [d.manufacturer, d.model].filter(Boolean).join(" ");
-      line += ` — ${hw}`;
-    }
-    parts.push(line);
-
-    // Second line: details
-    const details: string[] = [`id: ${d.id}`];
-    if (integrations.length > 0) details.push(`via: ${integrations.join(", ")}`);
-    if (area) details.push(`area: ${area}`);
-    if (d.disabled_by) details.push(`disabled: ${d.disabled_by}`);
-    if (d.via_device_id) details.push("has hub");
-    parts.push(`  ${details.join(" | ")}`);
-
-    lines.push(parts.join("\n"));
+    const area = d.area_id ? areaReg.get(d.area_id)?.name || "" : "";
+    const mfr = d.manufacturer || "";
+    const model = d.model || "";
+    const integ = integrations.join(", ");
+    const disabled = d.disabled_by ? " 🔴" : "";
+    lines.push(`| **${name}**${disabled} | ${mfr} | ${model} | ${integ} | ${area} | ${d.id} |`);
   }
 
   // Summary
@@ -307,12 +306,13 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
 
   let summary: string;
   if (total <= limit && offset === 0) {
-    summary = `Showing ${total} devices${disabledStr}`;
+    summary = `${total} devices${disabledStr}`;
   } else {
     summary = `Showing ${offset + 1}-${Math.min(offset + limit, total)} of ${total} devices${disabledStr}`;
   }
 
-  return lines.join("\n") + "\n\n" + summary;
+  lines.push(`\n${summary}`);
+  return lines.join("\n");
 }
 
 // ── Get ──────────────────────────────────────────────────────
@@ -397,7 +397,45 @@ async function handleGet(deviceId?: string): Promise<string> {
     }));
   }
 
-  return JSON.stringify(result, null, 2);
+  const lines: string[] = [];
+  const displayName = result.display_name || result.name || "(unnamed)";
+  lines.push(`## ${displayName}`);
+  lines.push("");
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
+  const topKeys = ["id", "name", "name_by_user", "manufacturer", "model", "hw_version", "sw_version", "serial_number", "integrations", "disabled_by", "entry_type", "configuration_url"];
+  for (const k of topKeys) {
+    const v = result[k];
+    if (v === null || v === undefined || v === "") continue;
+    const val = typeof v === "object" ? JSON.stringify(v) : String(v);
+    lines.push(`| ${k} | ${val} |`);
+  }
+  if (area) lines.push(`| area | ${area.name} (${area.id}) |`);
+  if (result.labels && (result.labels as string[]).length) lines.push(`| labels | ${(result.labels as string[]).join(", ")} |`);
+
+  const entities = result.entities as Array<{ entity_id: string; state?: string; platform?: string; name?: string; disabled_by?: string }>;
+  if (entities && entities.length > 0) {
+    lines.push("");
+    lines.push(`### Entities (${entities.length})`);
+    lines.push("");
+    lines.push("| Entity | State | Platform |");
+    lines.push("|--------|-------|----------|");
+    for (const e of entities) {
+      lines.push(`| ${e.entity_id} | ${e.state ?? "—"} | ${e.platform ?? "—"} |`);
+    }
+  }
+
+  const childDevices = result.child_devices as Array<{ id: string; name: string; manufacturer?: string; model?: string }> | undefined;
+  if (childDevices && childDevices.length > 0) {
+    lines.push("");
+    lines.push(`### Child Devices (${childDevices.length})`);
+    lines.push("");
+    for (const c of childDevices) {
+      lines.push(`- **${c.name}** (${c.id})${c.manufacturer ? ` — ${c.manufacturer}` : ""}${c.model ? ` ${c.model}` : ""}`);
+    }
+  }
+
+  return lines.join("\n");
 }
 
 // ── Update ───────────────────────────────────────────────────

--- a/.pi/extensions/home-assistant/tools/ha-docs.ts
+++ b/.pi/extensions/home-assistant/tools/ha-docs.ts
@@ -7,6 +7,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 export function registerDocsTool(pi: ExtensionAPI): void {
   pi.registerTool({
@@ -50,6 +51,15 @@ export function registerDocsTool(pi: ExtensionAPI): void {
         description: "Max lines to return for 'get' action (default: 200)",
       })),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Docs", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
@@ -254,15 +264,17 @@ async function executeAction(params: {
         const iCount = Object.keys(index.integrations).length;
         const dCount = Object.keys(index.docs).length;
         return [
-          "**Docs Index Status**",
+          "## Docs Index Status",
           "",
-          `Source: ${index.source}`,
-          `Version: ${index.version}`,
-          `Updated: ${index.updated}`,
-          `Commit: ${index.commit ?? "unknown"}`,
-          `Integrations: ${iCount}`,
-          `Docs: ${dCount}`,
-          `Data dir: ${DOCS_DATA_DIR}`,
+          "| Property | Value |",
+          "|----------|-------|",
+          `| Source | ${index.source} |`,
+          `| Version | ${index.version} |`,
+          `| Updated | ${index.updated} |`,
+          `| Commit | ${index.commit ?? "unknown"} |`,
+          `| Integrations | ${iCount} |`,
+          `| Docs | ${dCount} |`,
+          `| Data dir | ${DOCS_DATA_DIR} |`,
         ].join("\n");
       } catch {
         return `❌ No docs index found. Run update-docs.py to fetch from GitHub.\nData dir: ${DOCS_DATA_DIR}`;

--- a/.pi/extensions/home-assistant/tools/ha-entities.ts
+++ b/.pi/extensions/home-assistant/tools/ha-entities.ts
@@ -10,6 +10,7 @@ import { StringEnum } from "@mariozechner/pi-ai";
 import { apiGet } from "../lib/api.js";
 import { wsCommand } from "../lib/ws.js";
 import type { HAState } from "../lib/types.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -147,6 +148,15 @@ export function registerEntitiesTools(pi: ExtensionAPI): void {
       ),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Entities", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -240,31 +250,25 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
   const page = filtered.slice(offset, offset + limit);
 
   // Format output
-  const lines: string[] = [];
+  const lines: string[] = [
+    "| Entity | State | Name | Area |",
+    "|--------|-------|------|------|",
+  ];
   for (const s of page) {
-    const friendlyName = s.attributes.friendly_name as string | undefined;
+    const friendlyName = (s.attributes.friendly_name as string) || "";
     const regEntry = entityReg.get(s.entity_id);
-    const parts: string[] = [];
-
-    const nameStr = friendlyName ? ` (${friendlyName})` : "";
-    parts.push(`${s.entity_id}: ${s.state}${nameStr}`);
+    let area = "";
 
     if (regEntry?.device_id) {
       const device = deviceReg.get(regEntry.device_id);
-      if (device) {
-        const deviceName = device.name_by_user || device.name;
-        if (deviceName) {
-          const areaName = device.area_id ? areaReg.get(device.area_id)?.name : null;
-          const deviceStr = areaName ? `${deviceName} @ ${areaName}` : deviceName;
-          parts.push(`  device: ${deviceStr}`);
-        }
+      if (device?.area_id) {
+        area = areaReg.get(device.area_id)?.name || "";
       }
     } else if (regEntry?.area_id) {
-      const areaName = areaReg.get(regEntry.area_id)?.name;
-      if (areaName) parts.push(`  area: ${areaName}`);
+      area = areaReg.get(regEntry.area_id)?.name || "";
     }
 
-    lines.push(parts.join("\n"));
+    lines.push(`| ${s.entity_id} | ${s.state} | ${friendlyName} | ${area} |`);
   }
 
   const domainStr = params.domain ? `${params.domain} ` : "";
@@ -274,12 +278,13 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
 
   let summary: string;
   if (total <= limit && offset === 0) {
-    summary = `Showing ${total} ${domainStr}entities${filterStr}`;
+    summary = `${total} ${domainStr}entities${filterStr}`;
   } else {
     summary = `Showing ${offset + 1}-${Math.min(offset + limit, total)} of ${total} ${domainStr}entities${filterStr}`;
   }
 
-  return lines.join("\n") + "\n\n" + summary;
+  lines.push(`\n${summary}`);
+  return lines.join("\n");
 }
 
 async function handleGet(entityId?: string): Promise<string> {
@@ -321,7 +326,52 @@ async function handleGet(entityId?: string): Promise<string> {
     }
   }
 
-  return JSON.stringify(result, null, 2);
+  const lines: string[] = [];
+  lines.push(`## ${state.entity_id}`);
+  lines.push("");
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
+  lines.push(`| State | ${state.state} |`);
+  if (result.area) lines.push(`| Area | ${result.area} |`);
+  if (result.platform) lines.push(`| Platform | ${result.platform} |`);
+  if (result.icon) lines.push(`| Icon | ${result.icon} |`);
+  if (result.labels && (result.labels as string[]).length) lines.push(`| Labels | ${(result.labels as string[]).join(", ")} |`);
+  if (result.disabled_by) lines.push(`| Disabled by | ${result.disabled_by} |`);
+  if (result.hidden_by) lines.push(`| Hidden by | ${result.hidden_by} |`);
+  lines.push(`| Last changed | ${state.last_changed} |`);
+  lines.push(`| Last updated | ${state.last_updated} |`);
+
+  // Attributes
+  const skipAttrs = new Set(["friendly_name", "icon"]);
+  const attrs = state.attributes as Record<string, unknown>;
+  if (attrs && Object.keys(attrs).length > 0) {
+    lines.push("");
+    lines.push("### Attributes");
+    lines.push("");
+    lines.push("| Attribute | Value |");
+    lines.push("|-----------|-------|");
+    if (attrs.friendly_name) lines.push(`| friendly_name | ${attrs.friendly_name} |`);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (skipAttrs.has(k)) continue;
+      const val = typeof v === "object" ? JSON.stringify(v) : String(v);
+      lines.push(`| ${k} | ${val} |`);
+    }
+  }
+
+  // Device info
+  if (result.device) {
+    const dev = result.device as Record<string, unknown>;
+    lines.push("");
+    lines.push("### Device");
+    lines.push("");
+    lines.push("| Property | Value |");
+    lines.push("|----------|-------|");
+    for (const [k, v] of Object.entries(dev)) {
+      if (v !== null && v !== undefined) lines.push(`| ${k} | ${v} |`);
+    }
+  }
+
+  return lines.join("\n");
 }
 
 async function handleDomains(includeUnavailable?: boolean): Promise<string> {
@@ -338,18 +388,20 @@ async function handleDomains(includeUnavailable?: boolean): Promise<string> {
   }
 
   const sorted = Object.entries(domains).sort((a, b) => b[1].total - a[1].total);
-  const lines = sorted.map(([domain, counts]) => {
-    const unavailStr = counts.unavailable > 0 ? ` (${counts.unavailable} unavailable)` : "";
-    return `${domain}: ${counts.total}${unavailStr}`;
-  });
+  const lines: string[] = [
+    "| Domain | Count | Unavailable |",
+    "|--------|-------|-------------|",
+    ...sorted.map(([domain, counts]) => {
+      const unavail = counts.unavailable > 0 ? String(counts.unavailable) : "";
+      return `| ${domain} | ${counts.total} | ${unavail} |`;
+    }),
+  ];
 
   const totalUnavail = states.filter(
     (s) => s.state === "unavailable" || s.state === "unknown"
   ).length;
 
-  lines.push("");
-  lines.push(`Total: ${states.length} entities (${totalUnavail} unavailable/unknown)`);
-
+  lines.push(`\n${states.length} entities (${totalUnavail} unavailable/unknown)`);
   return lines.join("\n");
 }
 

--- a/.pi/extensions/home-assistant/tools/ha-events.ts
+++ b/.pi/extensions/home-assistant/tools/ha-events.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsSubscribe } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 interface HAEvent {
   event_type: string;
@@ -26,7 +27,7 @@ function formatTimestamp(iso: string): string {
 }
 
 function summarizeData(data: Record<string, unknown>, maxLen: number = 120): string {
-  if (!data || Object.keys(data).length === 0) return "";
+  if (!data || Object.keys(data).length === 0) return "(no data)";
   const json = JSON.stringify(data);
   if (json.length <= maxLen) return json;
   // Show key fields
@@ -45,29 +46,30 @@ function formatEvents(events: HAEvent[], limit: number): string {
   if (!events.length) return "No events captured during the listening period.";
 
   const shown = events.slice(0, limit);
-  const lines: string[] = [];
-
-  if (events.length > limit) {
-    lines.push(`Showing ${limit} of ${events.length} captured events:\n`);
-  } else {
-    lines.push(`Captured ${events.length} event${events.length !== 1 ? "s" : ""}:\n`);
-  }
 
   // Group by event_type for summary
   const typeCounts = new Map<string, number>();
   for (const e of events) {
     typeCounts.set(e.event_type, (typeCounts.get(e.event_type) || 0) + 1);
   }
+
+  const lines: string[] = [];
   if (typeCounts.size > 1) {
     lines.push("Event types: " + [...typeCounts.entries()].map(([t, c]) => `${t} (${c})`).join(", ") + "\n");
   }
 
+  lines.push("| Time | Event Type | Data |");
+  lines.push("|------|-----------|------|");
   for (const e of shown) {
     const time = formatTimestamp(e.time_fired);
-    const data = summarizeData(e.data);
-    lines.push(`  ${time}  ${e.event_type}${data ? "  " + data : ""}`);
+    const data = summarizeData(e.data).replace(/\|/g, "\\|");
+    lines.push(`| ${time} | ${e.event_type} | ${data} |`);
   }
 
+  const countLine = events.length > limit
+    ? `Showing ${limit} of ${events.length} events`
+    : `${events.length} events`;
+  lines.push(`\n${countLine}`);
   return lines.join("\n");
 }
 
@@ -91,6 +93,15 @@ export function registerEventsTool(pi: ExtensionAPI): void {
         description: "Max events to capture before stopping (default: 100)",
       })),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Events", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(_toolCallId, params, _signal, onUpdate) {
       const timeout = Math.min(params.timeout ?? 10, 60);

--- a/.pi/extensions/home-assistant/tools/ha-graph.ts
+++ b/.pi/extensions/home-assistant/tools/ha-graph.ts
@@ -12,6 +12,7 @@ import { HA_CONFIG_PATH } from "../lib/config.js";
 import { buildGraph } from "../lib/graph/graph-builder.js";
 import { saveGraph, loadGraph } from "../lib/graph/cache.js";
 import type { Graph, GraphEdge, NodeType } from "../lib/graph/types.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 export function registerGraphTool(pi: ExtensionAPI) {
   pi.registerTool({
@@ -32,6 +33,15 @@ export function registerGraphTool(pi: ExtensionAPI) {
         description: "Filter by node type: entity, automation, script, scene, dashboard, helper, area, label, device"
       })),
     }),
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("ha_graph", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params as Record<string, unknown>);
       return { content: [{ type: "text" as const, text: result }] };
@@ -108,13 +118,20 @@ function doStatus(): string {
   if (!graph) return "No graph cached. Run `build` first.";
 
   const counts = countByType(graph);
-  const lines = [`**Last built**: ${graph.buildTime}`];
-  lines.push(`**Nodes**: ${graph.nodes.size}`);
+  const lines = [
+    "## Graph Status",
+    "",
+    "| Property | Value |",
+    "|----------|-------|",
+    `| Last built | ${graph.buildTime} |`,
+    `| Nodes | ${graph.nodes.size} |`,
+    `| Edges | ${graph.edges.length} |`,
+  ];
+  if (graph.errors.length) lines.push(`| Errors | ${graph.errors.length} |`);
+  lines.push("", "### Nodes by type", "", "| Type | Count |", "|------|-------|");
   for (const [type, count] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
-    lines.push(`  ${type}: ${count}`);
+    lines.push(`| ${type} | ${count} |`);
   }
-  lines.push(`**Edges**: ${graph.edges.length}`);
-  if (graph.errors.length) lines.push(`**Errors**: ${graph.errors.length}`);
   return lines.join("\n");
 }
 
@@ -199,11 +216,16 @@ function doOrphans(nodeType?: string): string {
 
   if (orphans.length === 0) return `No orphaned ${filterType === "entity" ? "entities" : filterType + "s"} found.`;
 
-  const lines = [`**Orphaned ${filterType}s** (${orphans.length}) — registered but never referenced:`];
-  for (const o of orphans.slice(0, 50)) {
-    lines.push(`  ${o.id}${o.name && o.name !== o.id ? ` (${o.name})` : ""}`);
-  }
-  if (orphans.length > 50) lines.push(`  ... and ${orphans.length - 50} more`);
+  const shown = orphans.slice(0, 50);
+  const lines: string[] = [
+    "| ID | Name |",
+    "|----|------|",
+    ...shown.map((o) => `| ${o.id} | ${o.name && o.name !== o.id ? o.name : ""} |`),
+  ];
+  const countLine = orphans.length > 50
+    ? `Showing 50 of ${orphans.length} orphaned ${filterType}s`
+    : `${orphans.length} orphaned ${filterType}s`;
+  lines.push(`\n${countLine}`);
   return lines.join("\n");
 }
 
@@ -221,10 +243,12 @@ function doUnused(type: "label" | "area"): string {
 
   if (unused.length === 0) return `No unused ${type}s found.`;
 
-  const lines = [`**Unused ${type}s** (${unused.length}):`];
-  for (const u of unused) {
-    lines.push(`  ${u.id}${u.name && u.name !== u.id ? ` (${u.name})` : ""}`);
-  }
+  const lines: string[] = [
+    "| ID | Name |",
+    "|----|------|",
+    ...unused.map((u) => `| ${u.id} | ${u.name && u.name !== u.id ? u.name : ""} |`),
+    `\n${unused.length} unused ${type}s`,
+  ];
   return lines.join("\n");
 }
 
@@ -280,5 +304,6 @@ function doExport(): string {
     edges: graph.edges,
     errors: graph.errors,
   };
-  return JSON.stringify(exported, null, 2);
+  const json = JSON.stringify(exported, null, 2);
+  return `## Graph Export\n\n${exported.nodes ? Object.keys(exported.nodes).length : 0} nodes, ${exported.edges?.length ?? 0} edges\n\n\`\`\`json\n${json}\n\`\`\``;
 }

--- a/.pi/extensions/home-assistant/tools/ha-helpers.ts
+++ b/.pi/extensions/home-assistant/tools/ha-helpers.ts
@@ -24,6 +24,7 @@ import {
 } from "../lib/registry.js";
 import * as collectionWsBackend from "../lib/backends/collection-ws.js";
 import * as configEntryBackend from "../lib/backends/config-entry.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 
 // ── Tool registration ────────────────────────────────────────
@@ -61,6 +62,15 @@ export function registerHelperTool(pi: ExtensionAPI): void {
       ),
 
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Helpers", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
@@ -131,6 +141,48 @@ function handleListTypes(): string {
   return lines.join("\n");
 }
 
+function formatHelperItems(type: string, items: Record<string, unknown>[]): string {
+  // Internal/noisy fields to hide from list output
+  const skip = new Set([
+    "unique_id", "name", "title", "id", "entry_id",
+    "created_at", "modified_at", "source", "domain",
+    "supports_options", "supports_remove_device", "supports_unload",
+    "supports_reconfigure", "supported_subentry_types",
+    "pref_disable_new_entities", "pref_disable_polling",
+    "num_subentries", "state", "config_entry_id",
+  ]);
+
+  const lines: string[] = [];
+  lines.push(`| Name | ID | Details |`);
+  lines.push(`|------|-----|---------|`);
+  for (const item of items) {
+    const name = (item.name as string) || (item.title as string) || "(unnamed)";
+    const id = (item.id as string) || (item.entry_id as string) || "";
+    const details: string[] = [];
+    for (const [k, v] of Object.entries(item)) {
+      if (skip.has(k) || v === null || v === undefined || v === false || v === "") continue;
+      const val = typeof v === "object" ? JSON.stringify(v) : String(v);
+      if (val.length < 50) details.push(`${k}: ${val}`);
+    }
+    lines.push(`| ${name} | ${id} | ${details.join(", ") || "—"} |`);
+  }
+  return `**${type}** (${items.length})\n\n` + lines.join("\n");
+}
+
+function formatHelperDetail(type: string, item: Record<string, unknown>): string {
+  const name = (item.name as string) || (item.title as string) || "(unnamed)";
+  const lines: string[] = [`## ${type}: ${name}`];
+  lines.push("");
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
+  for (const [k, v] of Object.entries(item)) {
+    if (v === null || v === undefined) continue;
+    const val = typeof v === "object" ? JSON.stringify(v) : String(v);
+    lines.push(`| ${k} | ${val} |`);
+  }
+  return lines.join("\n");
+}
+
 async function handleList(type?: string): Promise<string> {
   if (type) {
     const t = requireType(type);
@@ -139,20 +191,22 @@ async function handleList(type?: string): Promise<string> {
       ? await collectionWsBackend.listItems(t)
       : await configEntryBackend.listEntries(t);
     if (items.length === 0) return `No ${type} helpers found.\n\n${formatSchema(type)}`;
-    return JSON.stringify(items, null, 2);
+    return formatHelperItems(type, items);
   }
 
   // List all types
-  const results: Record<string, unknown[]> = {};
+  const lines: string[] = [];
   for (const t of listTypes()) {
     const items = t.storageType === "collection"
       ? await collectionWsBackend.listItems(t)
       : await configEntryBackend.listEntries(t);
-    if (items.length > 0) results[t.domain] = items;
+    if (items.length > 0) {
+      lines.push(formatHelperItems(t.domain, items));
+    }
   }
 
-  if (Object.keys(results).length === 0) return "No helpers found.";
-  return JSON.stringify(results, null, 2);
+  if (lines.length === 0) return "No helpers found.";
+  return lines.join("\n\n");
 }
 
 async function handleGet(type?: string, id?: string): Promise<string> {
@@ -165,7 +219,7 @@ async function handleGet(type?: string, id?: string): Promise<string> {
     : await configEntryBackend.getEntry(t, id);
 
   if (!item) return `Helper '${id}' not found in ${type}.\n\n${formatSchema(type)}`;
-  return JSON.stringify(item, null, 2);
+  return formatHelperDetail(type, item);
 }
 
 async function handleAdd(type?: string, fields?: Record<string, unknown>): Promise<string> {

--- a/.pi/extensions/home-assistant/tools/ha-history.ts
+++ b/.pi/extensions/home-assistant/tools/ha-history.ts
@@ -8,7 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
-import { parseRelativeTime } from "../lib/format.js";
+import { parseRelativeTime , renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 /** Compressed state keys from HA history API */
 const S = "s";   // state
@@ -49,21 +49,33 @@ function formatHistory(
       states = states.slice(-limit);
     }
 
-    lines.push(`\n**${entityId}** (${total} state change${total !== 1 ? "s" : ""}${total > limit ? `, showing last ${limit}` : ""}):`);
+    const countLabel = total > limit ? `${total} changes, showing last ${limit}` : `${total} change${total !== 1 ? "s" : ""}`;
+    lines.push(`\n**${entityId}** (${countLabel}):\n`);
+
+    if (noAttributes) {
+      lines.push("| Time | State |");
+      lines.push("|------|-------|");
+    } else {
+      lines.push("| Time | State | Attributes |");
+      lines.push("|------|-------|------------|");
+    }
 
     for (const s of states) {
       const time = formatTimestamp(s[LU]);
-      let line = `  ${time}  →  ${s[S]}`;
-
+      let attrs = "";
       if (!noAttributes && s[A]) {
-        const attrs = Object.entries(s[A]!)
+        attrs = Object.entries(s[A]!)
           .filter(([k]) => !k.startsWith("_") && k !== "friendly_name" && k !== "icon")
           .map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : v}`)
-          .join(", ");
-        if (attrs) line += `  (${attrs})`;
+          .join(", ")
+          .replace(/\|/g, "\\|");
       }
 
-      lines.push(line);
+      if (noAttributes) {
+        lines.push(`| ${time} | ${s[S]} |`);
+      } else {
+        lines.push(`| ${time} | ${s[S]} | ${attrs} |`);
+      }
     }
   }
 
@@ -99,6 +111,15 @@ export function registerHistoryTool(pi: ExtensionAPI): void {
         description: "Max state changes per entity (default: 100)",
       })),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA History", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(_toolCallId, params) {
       const startTime = parseRelativeTime(params.start_time || "24h");

--- a/.pi/extensions/home-assistant/tools/ha-integrations.ts
+++ b/.pi/extensions/home-assistant/tools/ha-integrations.ts
@@ -8,7 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { apiGet, apiPost, apiDelete } from "../lib/api.js";
-import { timeSince } from "../lib/format.js";
+import { timeSince , renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -50,6 +50,15 @@ export function registerIntegrationsTool(pi: ExtensionAPI): void {
       ),
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Integrations", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
@@ -94,20 +103,15 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
   // Group by domain
   entries.sort((a, b) => a.domain.localeCompare(b.domain) || a.title.localeCompare(b.title));
 
-  const lines: string[] = [];
-  let currentDomain = "";
-  for (const e of entries) {
-    if (e.domain !== currentDomain) {
-      if (currentDomain) lines.push("");
-      currentDomain = e.domain;
-      lines.push(`## ${e.domain}`);
-    }
-    const status = e.disabled_by ? "🔴 disabled" : e.state === "loaded" ? "🟢" : `⚠️ ${e.state}`;
-    lines.push(`  ${status} ${e.title} (${e.entry_id})`);
-  }
-
-  lines.push("");
-  lines.push(`${entries.length} config entries`);
+  const lines: string[] = [
+    "| Status | Title | Domain | Entry ID |",
+    "|--------|-------|--------|----------|",
+    ...entries.map((e) => {
+      const status = e.disabled_by ? "🔴 disabled" : e.state === "loaded" ? "🟢" : `⚠️ ${e.state}`;
+      return `| ${status} | **${e.title}** | ${e.domain} | ${e.entry_id} |`;
+    }),
+    `\n${entries.length} config entries`,
+  ];
   return lines.join("\n");
 }
 
@@ -119,7 +123,7 @@ async function handleGet(entryId?: string): Promise<string> {
   if (!entry) throw new Error(`Config entry '${entryId}' not found`);
 
   const lines = [
-    `# ${entry.title}`,
+    `## ${entry.title}`,
     "",
     `| Field | Value |`,
     `|-------|-------|`,

--- a/.pi/extensions/home-assistant/tools/ha-labels.ts
+++ b/.pi/extensions/home-assistant/tools/ha-labels.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -51,6 +52,15 @@ export function registerLabelsTool(pi: ExtensionAPI): void {
       ),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Labels", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -78,16 +88,17 @@ async function handleList(): Promise<string> {
   if (labels.length === 0) return "No labels defined.";
 
   labels.sort((a, b) => a.name.localeCompare(b.name));
-  const lines = labels.map((l) => {
-    const parts = [l.name];
-    if (l.color) parts.push(`color: ${l.color}`);
-    if (l.icon) parts.push(`icon: ${l.icon}`);
-    if (l.description) parts.push(`"${l.description}"`);
-    return `${parts.join(" — ")} (id: ${l.label_id})`;
-  });
-
-  lines.push("");
-  lines.push(`${labels.length} labels`);
+  const lines: string[] = [
+    "| Name | Color | Icon | Description | ID |",
+    "|------|-------|------|-------------|----|",
+    ...labels.map((l) => {
+      const color = l.color || "";
+      const icon = l.icon || "";
+      const desc = l.description || "";
+      return `| **${l.name}** | ${color} | ${icon} | ${desc} | ${l.label_id} |`;
+    }),
+    `\n${labels.length} labels`,
+  ];
   return lines.join("\n");
 }
 

--- a/.pi/extensions/home-assistant/tools/ha-logbook.ts
+++ b/.pi/extensions/home-assistant/tools/ha-logbook.ts
@@ -8,7 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
-import { parseRelativeTime } from "../lib/format.js";
+import { parseRelativeTime , renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 interface LogbookEvent {
   when: number;       // timestamp
@@ -36,30 +36,30 @@ function formatEvents(events: LogbookEvent[], limit: number): string {
   const total = events.length;
   const shown = events.slice(0, limit);
 
-  const lines: string[] = [];
-  if (total > limit) {
-    lines.push(`Showing ${limit} of ${total} events:\n`);
-  }
+  const lines: string[] = [
+    "| Time | Entity | Event | State | Triggered by |",
+    "|------|--------|-------|-------|-------------|",
+  ];
 
   for (const e of shown) {
     const time = formatTimestamp(e.when);
     const name = e.name || e.entity_id || "Unknown";
-    const state = e.state ? ` → ${e.state}` : "";
-    const message = e.message ? ` ${e.message}` : "";
-    const entity = e.entity_id && e.entity_id !== e.name ? ` (${e.entity_id})` : "";
+    const message = e.message ? e.message.replace(/\|/g, "\\|") : "";
+    const state = e.state || "";
+    const entity = e.entity_id || "";
 
-    let line = `${time}  ${name}${entity}${message}${state}`;
-
-    // Add context if available (what triggered this)
+    let context = "";
     if (e.context_name || e.context_entity_id) {
       const ctx = e.context_name || e.context_entity_id;
       const ctxMsg = e.context_message ? ` ${e.context_message}` : "";
-      line += `  ← ${ctx}${ctxMsg}`;
+      context = `${ctx}${ctxMsg}`;
     }
 
-    lines.push(line);
+    lines.push(`| ${time} | **${name}**${entity && entity !== name ? ` (${entity})` : ""} | ${message} | ${state} | ${context} |`);
   }
 
+  const countLine = total > limit ? `Showing ${limit} of ${total} events` : `${total} events`;
+  lines.push(`\n${countLine}`);
   return lines.join("\n");
 }
 
@@ -92,6 +92,15 @@ export function registerLogbookTool(pi: ExtensionAPI): void {
         description: "Max events to return (default: 50)",
       })),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Logbook", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(_toolCallId, params) {
       const startTime = parseRelativeTime(params.start_time || "24h");

--- a/.pi/extensions/home-assistant/tools/ha-logs.ts
+++ b/.pi/extensions/home-assistant/tools/ha-logs.ts
@@ -8,6 +8,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { apiGet, apiPost } from "../lib/api.js";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 interface LogEntry {
   name: string;
@@ -73,20 +74,19 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
     DEBUG: "⚪",
   };
 
-  const lines: string[] = [];
+  const lines: string[] = [
+    "| Level | Name | Message | Source | Time | Count |",
+    "|-------|------|---------|--------|------|-------|",
+  ];
   for (const e of page) {
     const icon = levelIcons[e.level] || "⚪";
     const date = new Date(e.timestamp * 1000).toISOString().slice(0, 19);
-    const count = e.count > 1 ? ` (×${e.count})` : "";
-    lines.push(`${icon} [${e.level}] ${e.name}${count} — ${date}`);
-    lines.push(`  ${e.message[0]?.slice(0, 200) || "(no message)"}`);
-    if (e.source.length > 0) {
-      lines.push(`  source: ${e.source[0]}`);
-    }
+    const msg = (e.message[0]?.slice(0, 100) || "(no message)").replace(/\|/g, "\\|").replace(/\n/g, " ");
+    const src = e.source.length > 0 ? e.source[0] : "";
+    lines.push(`| ${icon} ${e.level} | ${e.name} | ${msg} | ${src} | ${date} | ${e.count > 1 ? `×${e.count}` : ""} |`);
   }
 
-  lines.push("");
-  lines.push(`${filtered.length} entries (showing ${page.length})`);
+  lines.push(`\n${filtered.length} entries (showing ${page.length})`);
   return lines.join("\n");
 }
 
@@ -137,6 +137,15 @@ export function registerLogsTool(pi: ExtensionAPI): void {
         Type.Number({ description: "Max entries/lines to return (default: 100 for get, 30 for list)" })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Logs", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await dispatch(params);

--- a/.pi/extensions/home-assistant/tools/ha-notifications.ts
+++ b/.pi/extensions/home-assistant/tools/ha-notifications.ts
@@ -8,7 +8,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
 import { apiPost } from "../lib/api.js";
-import { timeSince } from "../lib/format.js";
+import { timeSince , renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 interface PersistentNotification {
   notification_id: string;
@@ -27,17 +27,18 @@ async function handleList(): Promise<string> {
 
   notifications.sort((a, b) => b.created_at.localeCompare(a.created_at));
 
-  const lines: string[] = [];
+  const lines: string[] = [
+    "| Title | ID | Message | Created |",
+    "|-------|-----|---------|---------|",
+  ];
   for (const n of notifications) {
     const title = n.title || "(no title)";
     const ago = timeSince(n.created_at);
-    lines.push(`📌 ${title} (${ago})`);
-    lines.push(`  id: ${n.notification_id}`);
-    lines.push(`  ${n.message.slice(0, 200)}`);
+    const msg = n.message.slice(0, 80).replace(/\|/g, "\\|").replace(/\n/g, " ");
+    lines.push(`| **${title}** | ${n.notification_id} | ${msg} | ${ago} |`);
   }
 
-  lines.push("");
-  lines.push(`${notifications.length} notifications`);
+  lines.push(`\n${notifications.length} notifications`);
   return lines.join("\n");
 }
 
@@ -94,6 +95,15 @@ export function registerNotificationsTool(pi: ExtensionAPI): void {
         Type.String({ description: "Notification message (for create)" })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Notifications", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await dispatch(params);

--- a/.pi/extensions/home-assistant/tools/ha-people.ts
+++ b/.pi/extensions/home-assistant/tools/ha-people.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -41,6 +42,15 @@ export function registerPeopleTool(pi: ExtensionAPI): void {
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA People", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -69,15 +79,15 @@ async function handleList(): Promise<string> {
   if (people.length === 0) return "No people defined.";
 
   people.sort((a, b) => a.name.localeCompare(b.name));
-  const lines = people.map((p) => {
-    const parts = [`**${p.name}**`];
-    if (p.user_id) parts.push(`user: ${p.user_id}`);
-    if (p.device_trackers.length > 0) parts.push(`trackers: ${p.device_trackers.join(", ")}`);
-    return `${parts.join(" — ")} (id: ${p.id})`;
-  });
-
-  lines.push("");
-  lines.push(`${people.length} people`);
+  const lines: string[] = [
+    "| Name | User ID | Device Trackers | ID |",
+    "|------|---------|----------------|----|",
+    ...people.map((p) => {
+      const trackers = p.device_trackers.length > 0 ? p.device_trackers.join(", ") : "";
+      return `| **${p.name}** | ${p.user_id || ""} | ${trackers} | ${p.id} |`;
+    }),
+    `\n${people.length} people`,
+  ];
   return lines.join("\n");
 }
 
@@ -90,7 +100,7 @@ async function handleGet(id?: string): Promise<string> {
   if (!person) throw new Error(`Person '${id}' not found`);
 
   const lines = [
-    `# ${person.name}`,
+    `## ${person.name}`,
     "",
     `| Field | Value |`,
     `|-------|-------|`,

--- a/.pi/extensions/home-assistant/tools/ha-recorder.ts
+++ b/.pi/extensions/home-assistant/tools/ha-recorder.ts
@@ -9,6 +9,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
 import { apiPost } from "../lib/api.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Tool registration ────────────────────────────────────────
 
@@ -41,6 +42,15 @@ export function registerRecorderTool(pi: ExtensionAPI): void {
         Type.Boolean({ description: "Repack database after purge to free disk space (default: false)" })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Recorder", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);

--- a/.pi/extensions/home-assistant/tools/ha-restart.ts
+++ b/.pi/extensions/home-assistant/tools/ha-restart.ts
@@ -13,6 +13,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { requireToken, callService, apiPost } from "../lib/api.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 const RELOADABLE_DOMAINS = [
   "automation",
@@ -50,6 +51,15 @@ export function registerRestartTool(pi: ExtensionAPI): void {
         })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Restart", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);

--- a/.pi/extensions/home-assistant/tools/ha-scenes.ts
+++ b/.pi/extensions/home-assistant/tools/ha-scenes.ts
@@ -10,6 +10,7 @@ import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
 import { apiGet, apiPost, apiDelete } from "../lib/api.js";
 import type { HAState } from "../lib/types.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── List ─────────────────────────────────────────────────────
 
@@ -34,22 +35,22 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
 
   if (total === 0) return "No scenes found.";
 
-  const lines: string[] = [];
+  const lines: string[] = [
+    "| Name | Entity | Config ID |",
+    "|------|--------|-----------|",
+  ];
   for (const s of page) {
     const name = (s.attributes.friendly_name as string) || s.entity_id;
-    const configId = s.attributes.id as string;
-    const meta: string[] = [];
-    if (configId) meta.push(`id: ${configId}`);
-    meta.push(`entity: ${s.entity_id}`);
-    lines.push(`🎬 ${name}`);
-    lines.push(`  ${meta.join(" | ")}`);
+    const configId = (s.attributes.id as string) || "";
+    lines.push(`| **${name}** | ${s.entity_id} | ${configId} |`);
   }
 
   const summary = total <= limit && offset === 0
     ? `${total} scenes`
     : `Showing ${offset + 1}-${Math.min(offset + limit, total)} of ${total} scenes`;
 
-  return lines.join("\n") + "\n\n" + summary;
+  lines.push(`\n${summary}`);
+  return lines.join("\n");
 }
 
 // ── Get ──────────────────────────────────────────────────────
@@ -81,17 +82,35 @@ async function handleGet(params: Record<string, unknown>): Promise<string> {
     throw new Error("Scene not found. Provide a valid entity_id or scene_id.");
   }
 
-  const result: Record<string, unknown> = {};
+  const lines: string[] = [];
+  const name = state?.attributes.friendly_name || (config as Record<string, unknown>)?.name || sceneId || "(unnamed)";
+  lines.push(`## ${name}`);
+  lines.push("");
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
   if (state) {
-    result.entity_id = state.entity_id;
-    result.state = state.state;
-    result.friendly_name = state.attributes.friendly_name;
+    lines.push(`| Entity | ${state.entity_id} |`);
+    lines.push(`| State | ${state.state} |`);
   }
   if (config) {
-    result.config = config;
+    const c = config as Record<string, unknown>;
+    if (c.icon) lines.push(`| Icon | ${c.icon} |`);
+    const entities = c.entities as Record<string, unknown> | undefined;
+    if (entities) {
+      lines.push(`| Entities | ${Object.keys(entities).length} |`);
+      lines.push("");
+      lines.push("### Entity States");
+      lines.push("");
+      lines.push("| Entity | State |");
+      lines.push("|--------|-------|");
+      for (const [eid, st] of Object.entries(entities)) {
+        const val = typeof st === "object" ? JSON.stringify(st) : String(st);
+        lines.push(`| ${eid} | ${val} |`);
+      }
+    }
   }
 
-  return JSON.stringify(result, null, 2);
+  return lines.join("\n");
 }
 
 // ── Create ───────────────────────────────────────────────────
@@ -206,6 +225,15 @@ export function registerScenesTool(pi: ExtensionAPI): void {
       offset: Type.Optional(Type.Number({ description: "Pagination offset (default: 0)" })),
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm delete (default: false, preview only)" })),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Scenes", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await dispatch(params);

--- a/.pi/extensions/home-assistant/tools/ha-scripts.ts
+++ b/.pi/extensions/home-assistant/tools/ha-scripts.ts
@@ -9,8 +9,9 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
 import { apiGet, apiPost, apiDelete } from "../lib/api.js";
-import { timeSince } from "../lib/format.js";
+import { timeSince, formatTrace, renderMarkdownResult, renderToolCall } from "../lib/format.js";
 import type { HAState, TraceListEntry } from "../lib/types.js";
+import { toYaml } from "../lib/yaml.js";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -48,27 +49,26 @@ async function handleList(params: Record<string, unknown>): Promise<string> {
 
   if (total === 0) return "No scripts found.";
 
-  const lines: string[] = [];
+  const rows: string[] = [
+    "| | Name | Script ID | Mode | Last triggered |",
+    "|---|------|-----------|------|----------------|",
+  ];
   for (const s of page) {
     const name = (s.attributes.friendly_name as string) || s.entity_id;
     const lastTriggered = s.attributes.last_triggered as string;
-    const mode = s.attributes.mode as string;
+    const mode = (s.attributes.mode as string) || "single";
     const stateIcon = s.state === "on" ? "🔄" : "⏹️";
     const objectId = s.entity_id.replace("script.", "");
-
-    const meta: string[] = [`id: ${objectId}`];
-    if (mode && mode !== "single") meta.push(`mode: ${mode}`);
-    if (lastTriggered) meta.push(`last: ${timeSince(lastTriggered)}`);
-
-    lines.push(`${stateIcon} ${name}`);
-    lines.push(`  ${meta.join(" | ")}`);
+    const ago = lastTriggered ? timeSince(lastTriggered) : "—";
+    rows.push(`| ${stateIcon} | ${name} | ${objectId} | ${mode} | ${ago} |`);
   }
 
   const summary = total <= limit && offset === 0
     ? `${total} scripts`
     : `Showing ${offset + 1}-${Math.min(offset + limit, total)} of ${total} scripts`;
 
-  return lines.join("\n") + "\n\n" + summary;
+  rows.push(`\n${summary}`);
+  return rows.join("\n");
 }
 
 // ── Get ──────────────────────────────────────────────────────
@@ -105,20 +105,33 @@ async function handleGet(params: Record<string, unknown>): Promise<string> {
     throw new Error(`Script not found. Provide a valid entity_id or script_id.`);
   }
 
-  const result: Record<string, unknown> = {};
+  const lines: string[] = [];
+  const name = state?.attributes.friendly_name || config?.alias || scriptId || "(unnamed)";
+  lines.push(`## ${name}`);
+  lines.push("");
+  lines.push("| Property | Value |");
+  lines.push("|----------|-------|");
   if (state) {
-    result.entity_id = state.entity_id;
-    result.state = state.state;
-    result.friendly_name = state.attributes.friendly_name;
-    result.last_triggered = state.attributes.last_triggered;
-    result.mode = state.attributes.mode;
-    result.current = state.attributes.current;
+    lines.push(`| Entity | ${state.entity_id} |`);
+    lines.push(`| State | ${state.state} |`);
+    lines.push(`| Mode | ${state.attributes.mode || "single"} |`);
+    if (state.attributes.last_triggered) lines.push(`| Last triggered | ${state.attributes.last_triggered} |`);
+    if (state.attributes.current) lines.push(`| Current runs | ${state.attributes.current} |`);
   }
   if (config) {
-    result.config = config;
+    if (config.description) lines.push(`| Description | ${config.description} |`);
+    const seq = config.sequence as unknown[];
+    if (seq) lines.push(`| Actions | ${seq.length} step(s) |`);
+    if (config.fields) lines.push(`| Fields | ${Object.keys(config.fields as object).join(", ")} |`);
+    lines.push("");
+    lines.push("### Config");
+    lines.push("");
+    lines.push("```yaml");
+    lines.push(toYaml(config).trim());
+    lines.push("```");
   }
 
-  return JSON.stringify(result, null, 2);
+  return lines.join("\n");
 }
 
 // ── Create ───────────────────────────────────────────────────
@@ -208,17 +221,18 @@ async function handleTraces(params: Record<string, unknown>): Promise<string> {
   const limit = (params.limit as number) || 20;
   const page = traces.slice(0, limit);
 
-  const lines: string[] = [];
+  const lines: string[] = [
+    "| Status | Script | Execution | Run ID | Last Step | Time |",
+    "|--------|--------|-----------|--------|-----------|------|",
+  ];
   for (const t of page) {
     const stateIcon = t.state === "stopped" ? "✅" : t.state === "running" ? "🔄" : "❌";
     const ago = timeSince(t.timestamp.start);
     const execution = t.script_execution || "unknown";
-    lines.push(`${stateIcon} ${t.item_id} — ${execution} (${ago})`);
-    lines.push(`  run_id: ${t.run_id} | last_step: ${t.last_step || "none"}`);
+    lines.push(`| ${stateIcon} | ${t.item_id} | ${execution} | ${t.run_id} | ${t.last_step || "none"} | ${ago} |`);
   }
 
-  lines.push("");
-  lines.push(`${traces.length} traces total (showing ${page.length})`);
+  lines.push(`\n${traces.length} traces (showing ${page.length})`);
   return lines.join("\n");
 }
 
@@ -234,7 +248,7 @@ async function handleTrace(params: Record<string, unknown>): Promise<string> {
     run_id: runId,
   });
 
-  return JSON.stringify(trace, null, 2);
+  return formatTrace("script", scriptId, runId, trace);
 }
 
 // ── Tool registration ────────────────────────────────────────
@@ -287,6 +301,15 @@ export function registerScriptsTool(pi: ExtensionAPI): void {
         Type.Boolean({ description: "Set true to confirm delete (default: false, preview only)" })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Scripts", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await dispatch(params);

--- a/.pi/extensions/home-assistant/tools/ha-services.ts
+++ b/.pi/extensions/home-assistant/tools/ha-services.ts
@@ -9,6 +9,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { apiGet, requireToken } from "../lib/api.js";
 import { HA_URL, HA_TOKEN } from "../lib/config.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -53,6 +54,15 @@ export function registerServicesTool(pi: ExtensionAPI): void {
         })
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Services", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);

--- a/.pi/extensions/home-assistant/tools/ha-shopping-list.ts
+++ b/.pi/extensions/home-assistant/tools/ha-shopping-list.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -33,6 +34,15 @@ export function registerShoppingListTool(pi: ExtensionAPI): void {
       name: Type.Optional(Type.String({ description: "Item name (for add/update)" })),
       complete: Type.Optional(Type.Boolean({ description: "Mark as complete/incomplete (for update)" })),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Shopping List", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
@@ -60,26 +70,18 @@ async function handleList(): Promise<string> {
   const items = await wsCommand<ShoppingItem[]>("shopping_list/items");
   if (items.length === 0) return "Shopping list is empty.";
 
-  const incomplete = items.filter((i) => !i.complete);
-  const complete = items.filter((i) => i.complete);
-
-  const lines: string[] = [];
-  if (incomplete.length > 0) {
-    lines.push("## To buy");
-    for (const item of incomplete) {
-      lines.push(`  ☐ ${item.name} (id: ${item.id})`);
-    }
-  }
-  if (complete.length > 0) {
-    if (lines.length > 0) lines.push("");
-    lines.push("## Completed");
-    for (const item of complete) {
-      lines.push(`  ☑ ${item.name} (id: ${item.id})`);
-    }
+  const lines: string[] = [
+    "| Status | Name | ID |",
+    "|--------|------|----|",
+  ];
+  for (const item of items) {
+    const status = item.complete ? "☑" : "☐";
+    lines.push(`| ${status} | **${item.name}** | ${item.id} |`);
   }
 
-  lines.push("");
-  lines.push(`${items.length} items (${incomplete.length} to buy, ${complete.length} done)`);
+  const incomplete = items.filter((i) => !i.complete).length;
+  const complete = items.filter((i) => i.complete).length;
+  lines.push(`\n${items.length} items (${incomplete} to buy, ${complete} done)`);
   return lines.join("\n");
 }
 

--- a/.pi/extensions/home-assistant/tools/ha-stats.ts
+++ b/.pi/extensions/home-assistant/tools/ha-stats.ts
@@ -8,7 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
-import { parseRelativeTime } from "../lib/format.js";
+import { parseRelativeTime , renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 interface StatisticMetadata {
   statistic_id: string;
@@ -45,13 +45,17 @@ function formatNumber(n: number | null | undefined): string {
 function formatStatsList(metadata: StatisticMetadata[]): string {
   if (!metadata.length) return "No statistics available.";
 
-  const lines = [`**${metadata.length} statistic IDs available:**\n`];
-  for (const m of metadata) {
-    const unit = m.display_unit_of_measurement || m.statistics_unit_of_measurement || "";
-    const types = [m.has_mean ? "mean" : "", m.has_sum ? "sum" : ""].filter(Boolean).join(", ");
-    const name = m.name ? ` (${m.name})` : "";
-    lines.push(`  ${m.statistic_id}${name} — ${unit || "unitless"} [${types}] source:${m.source}`);
-  }
+  const lines: string[] = [
+    "| Statistic ID | Name | Unit | Types | Source |",
+    "|-------------|------|------|-------|--------|",
+    ...metadata.map((m) => {
+      const unit = m.display_unit_of_measurement || m.statistics_unit_of_measurement || "unitless";
+      const types = [m.has_mean ? "mean" : "", m.has_sum ? "sum" : ""].filter(Boolean).join(", ");
+      const name = m.name || "";
+      return `| ${m.statistic_id} | ${name} | ${unit} | ${types} | ${m.source} |`;
+    }),
+    `\n${metadata.length} statistics`,
+  ];
   return lines.join("\n");
 }
 
@@ -68,7 +72,7 @@ function formatStats(data: Record<string, StatisticRow[]>): string {
       continue;
     }
 
-    lines.push(`\n**${id}** (${rows.length} period${rows.length !== 1 ? "s" : ""}):`);
+    lines.push(`\n**${id}** (${rows.length} period${rows.length !== 1 ? "s" : ""}):\n`);
 
     // Determine which columns have data
     const hasMean = rows.some(r => r.mean != null);
@@ -78,24 +82,29 @@ function formatStats(data: Record<string, StatisticRow[]>): string {
     const hasState = rows.some(r => r.state != null);
     const hasChange = rows.some(r => r.change != null);
 
-    // Header
-    let header = "  Period Start          ";
-    if (hasMean) header += "  Mean";
-    if (hasMin) header += "    Min";
-    if (hasMax) header += "    Max";
-    if (hasSum) header += "    Sum";
-    if (hasState) header += "  State";
-    if (hasChange) header += "  Change";
+    // Build table header
+    let header = "| Period Start";
+    let sep = "|-------------";
+    if (hasMean) { header += " | Mean"; sep += " |-----"; }
+    if (hasMin) { header += " | Min"; sep += " |----"; }
+    if (hasMax) { header += " | Max"; sep += " |----"; }
+    if (hasSum) { header += " | Sum"; sep += " |----"; }
+    if (hasState) { header += " | State"; sep += " |------"; }
+    if (hasChange) { header += " | Change"; sep += " |-------"; }
+    header += " |";
+    sep += " |";
     lines.push(header);
+    lines.push(sep);
 
     for (const r of rows) {
-      let line = `  ${formatTimestamp(r.start)}`;
-      if (hasMean) line += `  ${formatNumber(r.mean).padStart(6)}`;
-      if (hasMin) line += `  ${formatNumber(r.min).padStart(6)}`;
-      if (hasMax) line += `  ${formatNumber(r.max).padStart(6)}`;
-      if (hasSum) line += `  ${formatNumber(r.sum).padStart(6)}`;
-      if (hasState) line += `  ${formatNumber(r.state).padStart(6)}`;
-      if (hasChange) line += `  ${formatNumber(r.change).padStart(6)}`;
+      let line = `| ${formatTimestamp(r.start)}`;
+      if (hasMean) line += ` | ${formatNumber(r.mean)}`;
+      if (hasMin) line += ` | ${formatNumber(r.min)}`;
+      if (hasMax) line += ` | ${formatNumber(r.max)}`;
+      if (hasSum) line += ` | ${formatNumber(r.sum)}`;
+      if (hasState) line += ` | ${formatNumber(r.state)}`;
+      if (hasChange) line += ` | ${formatNumber(r.change)}`;
+      line += " |";
       lines.push(line);
     }
   }
@@ -133,6 +142,15 @@ export function registerStatsTool(pi: ExtensionAPI): void {
         { description: "Statistics types to include" }
       )),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Statistics", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(_toolCallId, params) {
       if (params.action === "list") {

--- a/.pi/extensions/home-assistant/tools/ha-system.ts
+++ b/.pi/extensions/home-assistant/tools/ha-system.ts
@@ -7,6 +7,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { supervisorApi } from "../lib/supervisor.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 export function registerSystemTool(pi: ExtensionAPI): void {
   pi.registerTool({
@@ -20,6 +21,15 @@ export function registerSystemTool(pi: ExtensionAPI): void {
         { description: "Action to perform" }
       ),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA System", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params.action);
@@ -37,47 +47,55 @@ async function executeAction(action: string): Promise<string> {
   switch (action) {
     case "info": {
       const d = await supervisorApi<Record<string, unknown>>("/supervisor/info");
-      return [
-        "**Supervisor Info**",
+      const rows = [
+        "## Supervisor Info",
         "",
-        `Version: ${d.version}`,
-        `Channel: ${d.channel}`,
-        `Architecture: ${d.arch}`,
-        `Supported: ${d.supported ? "✅" : "❌"}`,
-        `Healthy: ${d.healthy ? "✅" : "❌"}`,
-        ...(d.update_available ? [`Update available: ${d.version_latest}`] : []),
-        `Timezone: ${d.timezone}`,
-        `Logging: ${d.logging}`,
-      ].join("\n");
+        "| Property | Value |",
+        "|----------|-------|",
+        `| Version | ${d.version} |`,
+        `| Channel | ${d.channel} |`,
+        `| Architecture | ${d.arch} |`,
+        `| Supported | ${d.supported ? "✅" : "❌"} |`,
+        `| Healthy | ${d.healthy ? "✅" : "❌"} |`,
+      ];
+      if (d.update_available) rows.push(`| Update available | ${d.version_latest} |`);
+      rows.push(`| Timezone | ${d.timezone} |`);
+      rows.push(`| Logging | ${d.logging} |`);
+      return rows.join("\n");
     }
 
     case "host": {
       const d = await supervisorApi<Record<string, unknown>>("/host/info");
-      const parts = [
-        "**Host Info**",
+      const rows = [
+        "## Host Info",
         "",
-        `Hostname: ${d.hostname}`,
-        `Operating System: ${d.operating_system}`,
-        `Kernel: ${d.kernel}`,
-        `CPUs: ${d.cpe ?? "?"}`,
+        "| Property | Value |",
+        "|----------|-------|",
+        `| Hostname | ${d.hostname} |`,
+        `| Operating System | ${d.operating_system} |`,
+        `| Kernel | ${d.kernel} |`,
+        `| CPUs | ${d.cpe ?? "?"} |`,
       ];
-      if (d.disk_total) parts.push(`Disk: ${formatBytes(d.disk_used as number)} / ${formatBytes(d.disk_total as number)} used`);
-      if (d.disk_free) parts.push(`Disk free: ${formatBytes(d.disk_free as number)}`);
-      if (Array.isArray(d.features) && d.features.length) parts.push(`Features: ${d.features.join(", ")}`);
-      return parts.join("\n");
+      if (d.disk_total) rows.push(`| Disk | ${formatBytes(d.disk_used as number)} / ${formatBytes(d.disk_total as number)} used |`);
+      if (d.disk_free) rows.push(`| Disk free | ${formatBytes(d.disk_free as number)} |`);
+      if (Array.isArray(d.features) && d.features.length) rows.push(`| Features | ${d.features.join(", ")} |`);
+      return rows.join("\n");
     }
 
     case "os": {
       const d = await supervisorApi<Record<string, unknown>>("/os/info");
-      return [
-        "**HAOS Info**",
+      const rows = [
+        "## HAOS Info",
         "",
-        `Version: ${d.version}`,
-        ...(d.update_available ? [`Update available: ${d.version_latest}`] : []),
-        `Board: ${d.board}`,
-        `Boot slot: ${d.boot_slot ?? d.boot ?? "?"}`,
-        ...(d.data_disk ? [`Data disk: ${d.data_disk}`] : []),
-      ].join("\n");
+        "| Property | Value |",
+        "|----------|-------|",
+        `| Version | ${d.version} |`,
+      ];
+      if (d.update_available) rows.push(`| Update available | ${d.version_latest} |`);
+      rows.push(`| Board | ${d.board} |`);
+      rows.push(`| Boot slot | ${d.boot_slot ?? d.boot ?? "?"} |`);
+      if (d.data_disk) rows.push(`| Data disk | ${d.data_disk} |`);
+      return rows.join("\n");
     }
 
     case "network": {
@@ -85,15 +103,18 @@ async function executeAction(action: string): Promise<string> {
       const interfaces = d.interfaces as Array<Record<string, unknown>> | undefined;
       if (!interfaces?.length) return "No network interfaces found.";
 
-      const parts = ["**Network Interfaces**", ""];
+      const parts = ["## Network Interfaces", ""];
       for (const iface of interfaces) {
         parts.push(`### ${iface.interface ?? iface.name ?? "?"} (${iface.type ?? "?"})`);
-        if (iface.enabled !== undefined) parts.push(`Enabled: ${iface.enabled}`);
-        if (iface.connected !== undefined) parts.push(`Connected: ${iface.connected}`);
+        parts.push("");
+        parts.push("| Property | Value |");
+        parts.push("|----------|-------|");
+        if (iface.enabled !== undefined) parts.push(`| Enabled | ${iface.enabled} |`);
+        if (iface.connected !== undefined) parts.push(`| Connected | ${iface.connected} |`);
         const ipv4 = iface.ipv4 as Record<string, unknown> | undefined;
-        if (ipv4?.address) parts.push(`IPv4: ${Array.isArray(ipv4.address) ? ipv4.address.join(", ") : ipv4.address}`);
-        if (ipv4?.gateway) parts.push(`Gateway: ${ipv4.gateway}`);
-        if (ipv4?.nameservers) parts.push(`DNS: ${Array.isArray(ipv4.nameservers) ? ipv4.nameservers.join(", ") : ipv4.nameservers}`);
+        if (ipv4?.address) parts.push(`| IPv4 | ${Array.isArray(ipv4.address) ? ipv4.address.join(", ") : ipv4.address} |`);
+        if (ipv4?.gateway) parts.push(`| Gateway | ${ipv4.gateway} |`);
+        if (ipv4?.nameservers) parts.push(`| DNS | ${Array.isArray(ipv4.nameservers) ? ipv4.nameservers.join(", ") : ipv4.nameservers} |`);
         parts.push("");
       }
       return parts.join("\n");

--- a/.pi/extensions/home-assistant/tools/ha-tags.ts
+++ b/.pi/extensions/home-assistant/tools/ha-tags.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -38,6 +39,15 @@ export function registerTagsTool(pi: ExtensionAPI): void {
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Tags", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -64,16 +74,17 @@ async function handleList(): Promise<string> {
   const tags = await wsCommand<WSTag[]>("tag/list");
   if (tags.length === 0) return "No tags defined.";
 
-  const lines = tags.map((t) => {
-    const parts = [t.name || "(unnamed)"];
-    parts.push(`tag_id: ${t.tag_id}`);
-    if (t.description) parts.push(`"${t.description}"`);
-    if (t.last_scanned) parts.push(`last scanned: ${t.last_scanned}`);
-    return `${parts.join(" — ")} (id: ${t.id})`;
-  });
-
-  lines.push("");
-  lines.push(`${tags.length} tags`);
+  const lines: string[] = [
+    "| Name | Tag ID | Description | Last Scanned | ID |",
+    "|------|--------|-------------|--------------|-----|",
+    ...tags.map((t) => {
+      const name = t.name || "(unnamed)";
+      const desc = t.description || "";
+      const scanned = t.last_scanned || "never";
+      return `| **${name}** | ${t.tag_id} | ${desc} | ${scanned} | ${t.id} |`;
+    }),
+    `\n${tags.length} tags`,
+  ];
   return lines.join("\n");
 }
 
@@ -85,7 +96,7 @@ async function handleGet(id?: string): Promise<string> {
   if (!tag) throw new Error(`Tag '${id}' not found`);
 
   return [
-    `# ${tag.name || "(unnamed)"}`,
+    `## ${tag.name || "(unnamed)"}`,
     "",
     `| Field | Value |`,
     `|-------|-------|`,

--- a/.pi/extensions/home-assistant/tools/ha-template.ts
+++ b/.pi/extensions/home-assistant/tools/ha-template.ts
@@ -10,6 +10,7 @@ import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { requireToken } from "../lib/api.js";
 import { HA_URL, HA_TOKEN } from "../lib/config.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 async function renderTemplate(template: string): Promise<{ success: boolean; result: string }> {
   requireToken();
@@ -46,6 +47,15 @@ export function registerTemplateTool(pi: ExtensionAPI): void {
         description: "Jinja2 template string, e.g. {{ states('sensor.temperature') }}",
       }),
     }),
+
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Template", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const { action, template } = params;

--- a/.pi/extensions/home-assistant/tools/ha-tool-docs.ts
+++ b/.pi/extensions/home-assistant/tools/ha-tool-docs.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { supportedDomains } from "../lib/registry.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 const RELOADABLE_DOMAINS = [
   "automation", "conversation", "frontend", "input_boolean", "input_button",
@@ -393,6 +394,58 @@ Actions:
 
 Templates have access to all HA template functions: states(), is_state(), state_attr(), now(), as_timestamp(), etc.`,
 
+    questionnaire: `## questionnaire — Interactive Question UI
+
+Ask the user one or more questions with a visual selection interface.
+Single question: simple options list. Multiple questions: tab-based navigation.
+
+Parameters:
+- questions: Array of question objects, each with:
+  - id: Unique identifier (e.g., "entity_naming")
+  - label: Short label for tab bar (e.g., "Naming")
+  - prompt: Full question text displayed to the user
+  - options: Array of { value, label, description? }
+  - allowOther: Allow free-text input (default: true)
+
+Returns structured answers with question id, selected value, label, and whether custom text was entered.
+
+Best practices:
+- Keep options concise — use descriptions for explanations
+- Use 1-3 questions per call for focused decision-making
+- Include concrete examples from the user's system in descriptions`,
+
+    ha_policies: `## ha_policies — User-Defined Policies
+
+Manages naming conventions, organization preferences, and other policies the AI should follow consistently.
+Policies are stored in \`/homeassistant/pi-agent/policies.yaml\` — human-readable, survives backups/restores.
+
+Actions:
+- list: Show all current policies formatted for reading.
+- get: Get a specific policy category. Requires: category.
+- set: Set/update policies. Requires: category + (key & value, or fields object).
+- remove: Remove a policy category or key within it. Requires: category, optional: key.
+- init: Scan the system and return analysis data to power the guided setup wizard conversation.
+- check: Audit entities against defined policies — finds _2/_3 suffixes, brand names in IDs, etc.
+
+Policy categories: naming, organization, automations, dashboards, language, general.
+
+The \`init\` action scans all entities and returns:
+- Domain breakdown, naming pattern samples
+- Problematic names (_2/_3 suffixes, brand names in IDs)
+- Metric sensor analysis (power/energy/voltage/etc.)
+- Integration detection
+
+Use this data to guide the user through an educational setup conversation.
+The wizard should show examples from the user's own devices, explain concepts in plain language, and propose conventions with sensible defaults.
+
+The 'language' category supports multilingual setups with mapping tables:
+- areas: { "Kitchen": "Køkken", "Bedroom": "Soveværelse" }
+- device_types: { "ceiling light": "loftlampe", "motion sensor": "bevægelsessensor" }
+- metrics: { "power": "effekt", "energy": "energi", "temperature": "temperatur" }
+- common_words: { "on": "tændt", "off": "slukket" }
+
+The 'check' action validates language mappings — reports unmapped device types, metrics, and areas.`,
+
     ha_zones: `## ha_zones — Manage Zones
 
 Actions:
@@ -418,6 +471,15 @@ export function registerToolDocsTool(pi: ExtensionAPI) {
     parameters: Type.Object({
       tool: Type.String({ description: "Tool name (e.g. 'ha_zones') or 'all'" }),
     }),
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Tool Docs", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(_id, params, _signal, _onUpdate, _ctx) {
       if (params.tool === "all") {
         const list = Object.keys(TOOL_DOCS)

--- a/.pi/extensions/home-assistant/tools/ha-zones.ts
+++ b/.pi/extensions/home-assistant/tools/ha-zones.ts
@@ -8,6 +8,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { StringEnum } from "@mariozechner/pi-ai";
 import { wsCommand } from "../lib/ws.js";
+import { renderMarkdownResult, renderToolCall } from "../lib/format.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -43,6 +44,15 @@ export function registerZonesTool(pi: ExtensionAPI): void {
       confirm: Type.Optional(Type.Boolean({ description: "Set true to confirm destructive actions (default: false, preview only)" })),
     }),
 
+
+    renderCall(args: Record<string, unknown>, theme: any) {
+      return renderToolCall("HA Zones", args, theme);
+    },
+
+    renderResult(result: any) {
+      return renderMarkdownResult(result);
+    },
+
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const result = await executeAction(params);
       return { content: [{ type: "text" as const, text: result }] };
@@ -70,17 +80,15 @@ async function handleList(): Promise<string> {
   if (zones.length === 0) return "No custom zones defined.";
 
   zones.sort((a, b) => a.name.localeCompare(b.name));
-  const lines = zones.map((z) => {
-    const parts = [`**${z.name}**`];
-    parts.push(`📍 ${z.latitude.toFixed(4)}, ${z.longitude.toFixed(4)}`);
-    parts.push(`radius: ${z.radius}m`);
-    if (z.icon) parts.push(z.icon);
-    if (z.passive) parts.push("(passive)");
-    return `${parts.join(" — ")} (id: ${z.id})`;
-  });
-
-  lines.push("");
-  lines.push(`${zones.length} zones`);
+  const lines: string[] = [
+    "| Name | Location | Radius | Icon | Passive | ID |",
+    "|------|----------|--------|------|---------|-----|",
+    ...zones.map((z) => {
+      const loc = `${z.latitude.toFixed(4)}, ${z.longitude.toFixed(4)}`;
+      return `| **${z.name}** | ${loc} | ${z.radius}m | ${z.icon || ""} | ${z.passive ? "yes" : ""} | ${z.id} |`;
+    }),
+    `\n${zones.length} zones`,
+  ];
   return lines.join("\n");
 }
 
@@ -92,7 +100,7 @@ async function handleGet(id?: string): Promise<string> {
   if (!zone) throw new Error(`Zone '${id}' not found`);
 
   return [
-    `# ${zone.name}`,
+    `## ${zone.name}`,
     "",
     `| Field | Value |`,
     `|-------|-------|`,


### PR DESCRIPTION
Standardize all tool outputs to follow the Tool Output Formatting Standard:

- **List actions** → markdown tables with 3-5 columns + count summary
- **Detail/get actions** → `##` heading + property tables + sub-sections
- **Action confirmations** → ✅/⚠️/❌ prefix format
- **Empty results** → meaningful messages (never empty strings)
- **Config/schema** → code blocks
- **Status icons** → 🟢 on, 🔴 off, ⚪ unknown

All 34 tools audited and aligned. Tested live on dev VM — user validated.