### PR TITLE
fix: ensure release-please triggers Docker build automatically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,18 @@ name: Build and Publish Add-on
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag (e.g., v0.9.0)"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., v0.9.0)"
+        required: true
+        type: string
   pull_request:
     branches:
       - main
@@ -28,9 +40,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Login to GHCR
-        if: github.event_name == 'release'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -40,7 +54,9 @@ jobs:
       - name: Get version
         id: version
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            echo "version=${{ inputs.tag }}" | sed 's/version=v/version=/' >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
             echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
           else
             echo "version=$(grep '^version:' addon/config.yaml | awk '{print $2}' | tr -d '\"')" >> "$GITHUB_OUTPUT"
@@ -53,4 +69,4 @@ jobs:
             --${{ matrix.arch }} \
             --target ${{ env.ADDON_TARGET }} \
             --version "${{ steps.version.outputs.version }}" \
-            ${{ github.event_name == 'release' && '--no-cache' || '--test' }}
+            ${{ github.event_name == 'pull_request' && '--test' || '--no-cache' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,12 +8,24 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build:
+    needs: release
+    if: needs.release.outputs.release_created == 'true'
+    uses: ./.github/workflows/build.yaml
+    with:
+      tag: ${{ needs.release.outputs.tag_name }}


### PR DESCRIPTION
## Problem

release-please uses `GITHUB_TOKEN` which **cannot trigger other workflows** (GitHub security limitation). This meant the `release: published` event on build.yaml was never fired automatically — Docker images weren't built on release.

## Fix

The release workflow now calls build.yaml directly via `workflow_call` after release-please creates a release. This keeps everything in the same workflow run, bypassing the cross-workflow trigger limitation.

## Changes

- **release.yaml**: Captures `release_created` and `tag_name` outputs, calls build.yaml when a release is created
- **build.yaml**: Adds `workflow_call` and `workflow_dispatch` triggers, uses `inputs.tag` for checkout and version

## Flow after this fix

```
push to main → release.yaml runs
  → release-please creates/updates release PR
  → when release PR is merged: creates GitHub Release
  → build job triggers via workflow_call
  → Docker images built and pushed to GHCR
```