### PR TITLE
fix: sync extension source into addon build context before deploy

### DIFF
--- a/.pi/skills/ha-dev/scripts/deploy-addon
+++ b/.pi/skills/ha-dev/scripts/deploy-addon
@@ -34,6 +34,12 @@ if ! $SSH_CMD echo "SSH OK" 2>/dev/null; then
   exit 1
 fi
 
+echo "==> Syncing extension source into addon build context..."
+rm -rf "$ADDON_DIR/extensions/home-assistant"
+mkdir -p "$ADDON_DIR/extensions"
+cp -a "$REPO_ROOT/.pi/extensions/home-assistant" "$ADDON_DIR/extensions/home-assistant"
+rm -rf "$ADDON_DIR/extensions/home-assistant/node_modules" "$ADDON_DIR/extensions/home-assistant/data"
+
 echo "==> Cleaning remote /addons/${ADDON_SLUG}/"
 $SSH_CMD "rm -rf /addons/${ADDON_SLUG} && mkdir -p /addons/${ADDON_SLUG}"
 

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: Pi Agent for Home Assistant
-version: 0.9.0
+version: 0.9.1
 slug: pi_agent
 image: ghcr.io/dkmaker/hass-pi-agent/{arch}-pi_agent
 description: >-


### PR DESCRIPTION
deploy-addon now copies `.pi/extensions/home-assistant/` into `addon/extensions/home-assistant/` before SCP, ensuring the container always ships the current extension.

Bumps version to 0.9.1.

Fixes #7wn51uvg