### PR TITLE
fix: clean up legacy extension copy from volume on startup

### DIFF
--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -1,5 +1,5 @@
 name: Pi Agent for Home Assistant
-version: 0.9.2
+version: 0.9.6
 slug: pi_agent
 image: ghcr.io/dkmaker/hass-pi-agent/{arch}-pi_agent
 description: >-

--- a/addon/rootfs/etc/s6-overlay/s6-rc.d/init-pi/run
+++ b/addon/rootfs/etc/s6-overlay/s6-rc.d/init-pi/run
@@ -85,6 +85,12 @@ fi
 tmp=$(mktemp)
 jq '. + {"quietStartup": true, "collapseChangelog": true}' "${PI_SETTINGS}" > "$tmp" && mv "$tmp" "${PI_SETTINGS}"
 
+# --- Clean up legacy extension copy from /homeassistant volume ---
+if [[ -d /homeassistant/.pi/extensions/home-assistant ]]; then
+    bashio::log.info 'Removing legacy extension from /homeassistant/.pi/extensions/home-assistant...'
+    rm -rf /homeassistant/.pi/extensions/home-assistant
+fi
+
 # --- Convenient symlinks ---
 ln -sf /homeassistant /root/homeassistant
 ln -sf /share /root/share


### PR DESCRIPTION
Remove /homeassistant/.pi/extensions/home-assistant on startup if it exists from the old init-extension approach. Prevents stale auto-discovery. Bump to 0.9.6.