### PR TITLE
feat: add HA status line in TUI footer and MQTT client tools

### DIFF
--- a/.pi/extensions/home-assistant/index.ts
+++ b/.pi/extensions/home-assistant/index.ts
@@ -147,6 +147,22 @@ ${addonLines || "No add-ons installed"}${areaLine}`;
       { triggerTurn: false },
     );
 
+    // Persistent status line in TUI footer
+    const dim = (s: string) => ctx.ui.theme.fg("dim", s);
+    const accent = (s: string) => ctx.ui.theme.fg("accent", s);
+    const areaCount = haCtx.areas?.length || 0;
+    const runningAddons = haCtx.addons.filter((a) => a.running).length;
+    const ver = sys.ha_version.replace(/^(\d+\.\d+).*/, "$1");
+
+    const statusParts = [
+      `🏠 HA ${accent(ver)}`,
+      `${accent(String(haCtx.entities.total))} entities`,
+      `${accent(String(automationCount))} automations`,
+      `${accent(String(areaCount))} areas`,
+      `${accent(String(runningAddons))} add-ons`,
+    ];
+    ctx.ui.setStatus("ha", statusParts.join(dim(" · ")));
+
     // First-run: suggest policy setup if no policies file exists
     if (!policiesExist()) {
       pi.sendMessage(

--- a/addon/Dockerfile
+++ b/addon/Dockerfile
@@ -23,7 +23,8 @@ RUN apk add --no-cache \
     fd \
     ripgrep \
     tmux \
-    ttyd
+    ttyd \
+    mosquitto-clients
 
 # Install pi coding agent (pinned version)
 RUN npm install -g @mariozechner/pi-coding-agent@0.57.1


### PR DESCRIPTION
## Changes

### HA Status Line (TUI footer)
Adds a persistent status line in the Pi TUI footer showing key Home Assistant metrics at a glance:

`🏠 HA 2025.1 · 847 entities · 23 automations · 12 areas · 4 add-ons`

- Uses `ctx.ui.setStatus()` with themed colors (accent-colored numbers, dim separators)
- Reads from already-gathered HAContext — no extra API calls
- Complements the existing startup chat message as an always-visible indicator

### MQTT Client Tools
Adds `mosquitto-clients` package to the add-on Dockerfile, providing `mosquitto_pub` and `mosquitto_sub` for MQTT testing/debugging via bash.

Closes #or7ff70u, #hys5yl6s